### PR TITLE
Enable compatibility with multiple HuggingFace models

### DIFF
--- a/colbert/evaluation/loaders.py
+++ b/colbert/evaluation/loaders.py
@@ -163,7 +163,7 @@ def load_collection(collection_path):
                 print(f'{line_idx // 1000 // 1000}M', end=' ', flush=True)
 
             pid, passage, *rest = line.strip('\n\r ').split('\t')
-            assert pid == 'id' or int(pid) == line_idx
+            assert pid == 'id' or int(pid) == line_idx, (pid,line_idx)
 
             if len(rest) >= 1:
                 title = rest[0]

--- a/colbert/evaluation/loaders.py
+++ b/colbert/evaluation/loaders.py
@@ -163,7 +163,7 @@ def load_collection(collection_path):
                 print(f'{line_idx // 1000 // 1000}M', end=' ', flush=True)
 
             pid, passage, *rest = line.strip('\n\r ').split('\t')
-            assert pid == 'id' or int(pid) == line_idx, (pid,line_idx)
+            assert pid == 'id' or int(pid) == line_idx, f"pid={pid}, line_idx={line_idx}"
 
             if len(rest) >= 1:
                 title = rest[0]

--- a/colbert/infra/config/config.py
+++ b/colbert/infra/config/config.py
@@ -11,5 +11,5 @@ class RunConfig(BaseConfig, RunSettings):
 
 @dataclass
 class ColBERTConfig(RunSettings, ResourceSettings, DocSettings, QuerySettings, TrainingSettings,
-                    IndexingSettings, SearchSettings, BaseConfig):
+                    IndexingSettings, SearchSettings, BaseConfig, TokenizerSettings):
     pass

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -153,7 +153,7 @@ class TrainingSettings:
 
     ignore_scores: bool = DefaultVal(False)
     
-    model_name: str = DefaultVal(None)
+    model_name: str = DefaultVal("bert-base-uncased")
 
 @dataclass
 class IndexingSettings:

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -86,16 +86,14 @@ class RunSettings:
     def device_(self):
         return self.gpus_[self.rank % self.nranks]
 
-    
-    
+
 @dataclass
 class TokenizerSettings:
     query_token_id: str = DefaultVal("[unused0]")
     doc_token_id: str = DefaultVal("[unused1]")
     query_token: str = DefaultVal("[Q]")
     doc_token: str = DefaultVal("[D]")
-        
-        
+
 
 @dataclass
 class ResourceSettings:
@@ -152,7 +150,7 @@ class TrainingSettings:
     distillation_alpha: float = DefaultVal(1.0)
 
     ignore_scores: bool = DefaultVal(False)
-    
+
     model_name: str = DefaultVal("bert-base-uncased")
 
 @dataclass

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -86,6 +86,16 @@ class RunSettings:
     def device_(self):
         return self.gpus_[self.rank % self.nranks]
 
+    
+    
+@dataclass
+class TokenizerSettings:
+    query_token_id: str = DefaultVal("[unused0]")
+    doc_token_id: str = DefaultVal("[unused1]")
+    query_token: str = DefaultVal("[Q]")
+    doc_token: str = DefaultVal("[D]")
+        
+        
 
 @dataclass
 class ResourceSettings:
@@ -142,7 +152,8 @@ class TrainingSettings:
     distillation_alpha: float = DefaultVal(1.0)
 
     ignore_scores: bool = DefaultVal(False)
-
+    
+    model_name: str = DefaultVal(None)
 
 @dataclass
 class IndexingSettings:

--- a/colbert/modeling/base_colbert.py
+++ b/colbert/modeling/base_colbert.py
@@ -24,6 +24,7 @@ class BaseColBERT(torch.nn.Module):
 
         self.colbert_config = ColBERTConfig.from_existing(ColBERTConfig.load_from_checkpoint(name_or_path), colbert_config)
         self.name = self.colbert_config.model_name
+        assert self.name is not None
         HF_ColBERT = class_factory(self.name)
         self.model = HF_ColBERT.from_pretrained(name_or_path, colbert_config=self.colbert_config)
         self.raw_tokenizer = AutoTokenizer.from_pretrained(name_or_path)
@@ -41,7 +42,7 @@ class BaseColBERT(torch.nn.Module):
     @property
     def linear(self):
         return self.model.linear
-    
+
     @property
     def score_scaler(self):
         return self.model.score_scaler
@@ -67,13 +68,12 @@ if __name__ == '__main__':
     torch.manual_seed(12345)
 
     with Run().context(RunConfig(gpus=2)):
-        m = BaseColBERT('xlm-roberta-base', colbert_config=ColBERTConfig(Run().config, doc_maxlen=300, similarity='l2',model_name='xlm-roberta-base'))
-        print("PARAMETERS", m.bert.parameters())
+        m = BaseColBERT('bert-base-uncased', colbert_config=ColBERTConfig(Run().config, doc_maxlen=300, similarity='l2'))
         m.colbert_config.help()
         print(m.linear.weight)
-        m.save('/tmp/2021/08/model.deleteme2/')
+        m.save('/future/u/okhattab/tmp/2021/08/model.deleteme2/')
 
-    m2 = BaseColBERT('/tmp/2021/08/model.deleteme2/')
+    m2 = BaseColBERT('/future/u/okhattab/tmp/2021/08/model.deleteme2/')
     m2.colbert_config.help()
     print(m2.linear.weight)
 

--- a/colbert/modeling/base_colbert.py
+++ b/colbert/modeling/base_colbert.py
@@ -9,8 +9,6 @@ from colbert.modeling.hf_colbert import class_factory
 from colbert.infra.config import ColBERTConfig
 
 
-
-
 class BaseColBERT(torch.nn.Module):
     """
     Shallow module that wraps the ColBERT parameters, custom configuration, and underlying tokenizer.

--- a/colbert/modeling/colbert.py
+++ b/colbert/modeling/colbert.py
@@ -27,7 +27,7 @@ class ColBERT(BaseColBERT):
                              for symbol in string.punctuation
                              for w in [symbol, self.raw_tokenizer.encode(symbol, add_special_tokens=False)[0]]}
         self.pad_token = self.raw_tokenizer.pad_token_id
-        
+
 
     @classmethod
     def try_load_torch_extensions(cls, use_gpu):
@@ -88,7 +88,7 @@ class ColBERT(BaseColBERT):
 
         mask = torch.tensor(self.mask(input_ids, skiplist=[]), device=self.device).unsqueeze(2).float()
         Q = Q * mask
-        
+
         return torch.nn.functional.normalize(Q, p=2, dim=2)
 
     def doc(self, input_ids, attention_mask, keep_dims=True):
@@ -114,7 +114,7 @@ class ColBERT(BaseColBERT):
         return D
 
     def score(self, Q, D_padded, D_mask):
-        # assert self.colbert_config.similarity == 'cosine'        
+        # assert self.colbert_config.similarity == 'cosine'
         if self.colbert_config.similarity == 'l2':
             assert self.colbert_config.interaction == 'colbert'
             return (-1.0 * ((Q.unsqueeze(2) - D_padded.unsqueeze(1))**2).sum(-1)).max(-1).values.sum(-1)

--- a/colbert/modeling/hf_colbert.py
+++ b/colbert/modeling/hf_colbert.py
@@ -1,64 +1,157 @@
+import importlib
+from unicodedata import name
 import torch.nn as nn
-
-from transformers import BertPreTrainedModel, BertModel, AutoTokenizer
+import transformers
+from transformers import BertPreTrainedModel, BertModel, AutoTokenizer,AutoModel,AutoConfig
+from transformers import RobertaModel, RobertaPreTrainedModel
+from transformers import XLMRobertaModel,XLMRobertaConfig
+from transformers import ElectraModel, ElectraPreTrainedModel
+from transformers import DebertaV2Model, DebertaV2PreTrainedModel
 from colbert.utils.utils import torch_load_dnn
 
-
-class HF_ColBERT(BertPreTrainedModel):
+class XLMRobertaPreTrainedModel(RobertaPreTrainedModel):
     """
-        Shallow wrapper around HuggingFace transformers. All new parameters should be defined at this level.
+    This class overrides [`RobertaModel`]. Please check the superclass for the appropriate documentation alongside
+    usage examples.
+    """
+
+    config_class = XLMRobertaConfig 
+
+
+base_class_mapping={
+    "roberta-base":RobertaPreTrainedModel,
+    "google/electra-base-discriminator":ElectraPreTrainedModel,
+    "xlm-roberta-base":XLMRobertaPreTrainedModel,
+    "xlm-roberta-large":XLMRobertaPreTrainedModel,
+    "bert-base-uncased":BertPreTrainedModel,
+    "bert-large-uncased":BertPreTrainedModel,
+    "microsoft/mdeberta-v3-base":DebertaV2PreTrainedModel,
+    "bert-base-multilingual-uncased":BertPreTrainedModel
+    
+    
+}
+
+model_object_mapping = {
+    "roberta-base":RobertaModel,
+    "google/electra-base-discriminator":ElectraModel,
+    "xlm-roberta-base":XLMRobertaModel,
+    "xlm-roberta-large":XLMRobertaModel,
+    "bert-base-uncased":BertModel,
+    "bert-large-uncased":BertModel,
+    "microsoft/mdeberta-v3-base":DebertaV2Model,
+    "bert-base-multilingual-uncased":BertModel
+    
+}
+
+
+
+
+transformers_module =dir(transformers)
+
+def find_class_names(model_type,class_type):
+    model_type = model_type.replace("-","").lower()
+    for item in transformers_module:
+        if model_type+class_type==item.lower():
+            return item
         
-        This makes sure `{from,save}_pretrained` and `init_weights` are applied to new parameters correctly.
-    """
-    _keys_to_ignore_on_load_unexpected = [r"cls"]
+    return None
 
-    def __init__(self, config, colbert_config):
-        super().__init__(config)
 
-        self.dim = colbert_config.dim
-        self.bert = BertModel(config)
-        self.linear = nn.Linear(config.hidden_size, colbert_config.dim, bias=False)
+def class_factory(name_or_path):
+    # class_obj = base_class_mapping.get(name_or_path)
+    loadedConfig  = AutoConfig.from_pretrained(name_or_path)
+    model_type = loadedConfig.model_type
+    pretrained_class = find_class_names(model_type,'pretrainedmodel')
+    model_class = find_class_names(model_type,'model')
+    
+    if pretrained_class != None:
+        pretrained_class_object = getattr(transformers,pretrained_class)
+    elif model_type == 'xlm-roberta':
+        pretrained_class_object = XLMRobertaPreTrainedModel
+    elif base_class_mapping.get(name_or_path)!=None:
+        pretrained_class_object = base_class_mapping.get(name_or_path)
+    else:
+        raise RuntimeError("Could not find correct pretrained class for the model type in  transformers library ")
+    
+    if model_class != None:
+        model_class_object = getattr(transformers,model_class)
+    elif model_object_mapping.get(name_or_path)!=None:
+        model_class_object = model_object_mapping.get(name_or_path)
+    else:
+        raise RuntimeError("Could not find correct model class for the model type in  transformers library ")
+    
+    
 
-        # if colbert_config.relu:
-        #     self.score_scaler = nn.Linear(1, 1)
+    
+    class HF_ColBERT(pretrained_class_object):
+        """
+            Shallow wrapper around HuggingFace transformers. All new parameters should be defined at this level.
+            
+            This makes sure `{from,save}_pretrained` and `init_weights` are applied to new parameters correctly.
+        """
+        _keys_to_ignore_on_load_unexpected = [r"cls"]
 
-        self.init_weights()
+        def __init__(self, config, colbert_config):
+            super().__init__(config)
 
-        # if colbert_config.relu:
-        #     self.score_scaler.weight.data.fill_(1.0)
-        #     self.score_scaler.bias.data.fill_(-8.0)
+            self.config = config
+            self.dim = colbert_config.dim
+            self.linear = nn.Linear(config.hidden_size, colbert_config.dim, bias=False)
+            setattr(self,self.base_model_prefix,model_class_object(config))
 
-    @classmethod
-    def from_pretrained(cls, name_or_path, colbert_config):
-        if name_or_path.endswith('.dnn'):
-            dnn = torch_load_dnn(name_or_path)
-            base = dnn.get('arguments', {}).get('model', 'bert-base-uncased')
+            # if colbert_config.relu:
+            #     self.score_scaler = nn.Linear(1, 1)
 
-            obj = super().from_pretrained(base, state_dict=dnn['model_state_dict'], colbert_config=colbert_config)
-            obj.base = base
+            self.init_weights()
+
+            # if colbert_config.relu:
+            #     self.score_scaler.weight.data.fill_(1.0)
+            #     self.score_scaler.bias.data.fill_(-8.0)
+
+        @property
+        def LM(self):
+            base_model_prefix = getattr(self,"base_model_prefix")
+            return getattr(self,base_model_prefix)
+        
+        
+        @classmethod
+        def from_pretrained(cls, name_or_path, colbert_config):
+            if name_or_path.endswith('.dnn'):
+                dnn = torch_load_dnn(name_or_path)
+                base = dnn.get('arguments', {}).get('model', 'bert-base-uncased')
+
+                obj = super().from_pretrained(base, state_dict=dnn['model_state_dict'], colbert_config=colbert_config)
+                obj.base = base
+
+                return obj
+
+            obj = super().from_pretrained(name_or_path, colbert_config=colbert_config)
+            obj.base = name_or_path
 
             return obj
 
-        obj = super().from_pretrained(name_or_path, colbert_config=colbert_config)
-        obj.base = name_or_path
+        @staticmethod
+        def raw_tokenizer_from_pretrained(name_or_path):
+            if name_or_path.endswith('.dnn'):
+                dnn = torch_load_dnn(name_or_path)
+                base = dnn.get('arguments', {}).get('model', 'bert-base-uncased')
 
-        return obj
+                obj = AutoTokenizer.from_pretrained(base)
+                obj.base = base
 
-    @staticmethod
-    def raw_tokenizer_from_pretrained(name_or_path):
-        if name_or_path.endswith('.dnn'):
-            dnn = torch_load_dnn(name_or_path)
-            base = dnn.get('arguments', {}).get('model', 'bert-base-uncased')
+                return obj
 
-            obj = AutoTokenizer.from_pretrained(base)
-            obj.base = base
+            obj = AutoTokenizer.from_pretrained(name_or_path)
+            obj.base = name_or_path
 
             return obj
+        
+    return HF_ColBERT
 
-        obj = AutoTokenizer.from_pretrained(name_or_path)
-        obj.base = name_or_path
 
-        return obj
+
+
+
 
 """
 TODO: It's easy to write a class generator that takes "name_or_path" and loads AutoConfig to check the Architecture's

--- a/colbert/modeling/tokenization/doc_tokenization.py
+++ b/colbert/modeling/tokenization/doc_tokenization.py
@@ -19,8 +19,6 @@ class DocTokenizer():
         self.cls_token, self.cls_token_id = self.tok.cls_token, self.tok.cls_token_id
         self.sep_token, self.sep_token_id = self.tok.sep_token, self.tok.sep_token_id
 
-#         assert self.D_marker_token_id == 2
-
     def tokenize(self, batch_text, add_special_tokens=False):
         assert type(batch_text) in [list, tuple], (type(batch_text))
 

--- a/colbert/modeling/tokenization/doc_tokenization.py
+++ b/colbert/modeling/tokenization/doc_tokenization.py
@@ -2,23 +2,24 @@ import torch
 
 # from transformers import BertTokenizerFast
 
-from colbert.modeling.hf_colbert import HF_ColBERT
+from colbert.modeling.hf_colbert import class_factory
 from colbert.infra import ColBERTConfig
 from colbert.modeling.tokenization.utils import _split_into_batches, _sort_by_length
 
 
 class DocTokenizer():
     def __init__(self, config: ColBERTConfig):
+        HF_ColBERT = class_factory(config.checkpoint)
         self.tok = HF_ColBERT.raw_tokenizer_from_pretrained(config.checkpoint)
 
         self.config = config
         self.doc_maxlen = config.doc_maxlen
 
-        self.D_marker_token, self.D_marker_token_id = '[D]', self.tok.convert_tokens_to_ids('[unused1]')
+        self.D_marker_token, self.D_marker_token_id = self.config.doc_token, self.tok.convert_tokens_to_ids(self.config.doc_token_id)
         self.cls_token, self.cls_token_id = self.tok.cls_token, self.tok.cls_token_id
         self.sep_token, self.sep_token_id = self.tok.sep_token, self.tok.sep_token_id
 
-        assert self.D_marker_token_id == 2
+#         assert self.D_marker_token_id == 2
 
     def tokenize(self, batch_text, add_special_tokens=False):
         assert type(batch_text) in [list, tuple], (type(batch_text))

--- a/colbert/modeling/tokenization/query_tokenization.py
+++ b/colbert/modeling/tokenization/query_tokenization.py
@@ -20,7 +20,6 @@ class QueryTokenizer():
         self.sep_token, self.sep_token_id = self.tok.sep_token, self.tok.sep_token_id
         self.mask_token, self.mask_token_id = self.tok.mask_token, self.tok.mask_token_id
         self.pad_token,self.pad_token_id = self.tok.pad_token,self.tok.pad_token_id
-#         assert self.Q_marker_token_id == 1 and self.mask_token_id == 103
         self.used = False
 
     def tokenize(self, batch_text, add_special_tokens=False):

--- a/colbert/training/training.py
+++ b/colbert/training/training.py
@@ -116,7 +116,6 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
                     loss = torch.nn.KLDivLoss(reduction='batchmean', log_target=True)(log_scores, target_scores)
                 else:
                     loss = nn.CrossEntropyLoss()(scores, labels[:scores.size(0)])
-                
                 if config.use_ib_negatives:
                     if config.rank < 1:
                         print('\t\t\t\t', loss.item(), ib_loss.item())

--- a/colbert/training/training.py
+++ b/colbert/training/training.py
@@ -64,7 +64,7 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
         print(f"#> LR will use {config.warmup} warmup steps and linear decay over {config.maxsteps} steps.")
         scheduler = get_linear_schedule_with_warmup(optimizer, num_warmup_steps=config.warmup,
                                                     num_training_steps=config.maxsteps)
-    
+
     warmup_bert = config.warmup_bert
     if warmup_bert is not None:
         set_bert_grad(colbert, False)
@@ -116,6 +116,7 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
                     loss = torch.nn.KLDivLoss(reduction='batchmean', log_target=True)(log_scores, target_scores)
                 else:
                     loss = nn.CrossEntropyLoss()(scores, labels[:scores.size(0)])
+
                 if config.use_ib_negatives:
                     if config.rank < 1:
                         print('\t\t\t\t', loss.item(), ib_loss.item())
@@ -145,7 +146,7 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
         ckpt_path = manage_checkpoints(config, colbert, optimizer, batch_idx+1, savepath=None, consumed_all_triples=True)
 
         return ckpt_path  # TODO: This should validate and return the best checkpoint, not just the last one.
-    
+
 
 
 def set_bert_grad(colbert, value):

--- a/utility/preprocess/docs2passages.py
+++ b/utility/preprocess/docs2passages.py
@@ -3,6 +3,8 @@
 """
 
 import os
+import sys
+
 import math
 import ujson
 import random

--- a/utility/preprocess/docs2passages.py
+++ b/utility/preprocess/docs2passages.py
@@ -3,8 +3,6 @@
 """
 
 import os
-import sys
-
 import math
 import ujson
 import random


### PR DESCRIPTION
I have followed the 'todo' in the HF_colbert.py file (mostly) to add model compatibility. The changes in the 'if __name__ == '__main__':' section of base_colbert.py can be ignored I suppose that only exists for testing.