### PR TITLE
Add the option to use different Tokenizer/Vocabulary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 # mac
 .DS_Store
 
+# pip install
+*.egg-info
+
 # Other
 .vscode
 *.tsv

--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -19,8 +19,8 @@ class Checkpoint(ColBERT):
         super().__init__(name, colbert_config)
         assert self.training is False
 
-        self.query_tokenizer = QueryTokenizer(self.colbert_config)
-        self.doc_tokenizer = DocTokenizer(self.colbert_config)
+        self.query_tokenizer = QueryTokenizer(self.colbert_config, self.raw_tokenizer)
+        self.doc_tokenizer = DocTokenizer(self.colbert_config, self.raw_tokenizer)
 
         self.amp_manager = MixedPrecisionManager(True)
 

--- a/colbert/modeling/tokenization/doc_tokenization.py
+++ b/colbert/modeling/tokenization/doc_tokenization.py
@@ -7,21 +7,23 @@ from colbert.infra import ColBERTConfig
 from colbert.modeling.tokenization.utils import _split_into_batches, _sort_by_length
 
 
-class DocTokenizer():
-    def __init__(self, config: ColBERTConfig):
-        self.tok = HF_ColBERT.raw_tokenizer_from_pretrained(config.checkpoint)
+class DocTokenizer:
+    def __init__(self, config: ColBERTConfig, tok):
+        self.tok = tok
 
         self.config = config
         self.doc_maxlen = config.doc_maxlen
 
-        self.D_marker_token, self.D_marker_token_id = '[D]', self.tok.convert_tokens_to_ids('[unused1]')
+        self.D_marker_token = '[D]'
+        if '[unused1]' in self.tok.vocab:
+            self.D_marker_token_id = self.tok.convert_tokens_to_ids('[unused1]')
+        else:
+            self.D_marker_token_id = self.tok.convert_tokens_to_ids(self.D_marker_token)
         self.cls_token, self.cls_token_id = self.tok.cls_token, self.tok.cls_token_id
         self.sep_token, self.sep_token_id = self.tok.sep_token, self.tok.sep_token_id
 
-        assert self.D_marker_token_id == 2
-
     def tokenize(self, batch_text, add_special_tokens=False):
-        assert type(batch_text) in [list, tuple], (type(batch_text))
+        assert type(batch_text) in [list, tuple], type(batch_text)
 
         tokens = [self.tok.tokenize(x, add_special_tokens=False) for x in batch_text]
 

--- a/colbert/modeling/tokenization/query_tokenization.py
+++ b/colbert/modeling/tokenization/query_tokenization.py
@@ -7,19 +7,22 @@ from colbert.utils.utils import batch
 
 
 class QueryTokenizer():
-    def __init__(self, config: ColBERTConfig):
-        self.tok = HF_ColBERT.raw_tokenizer_from_pretrained(config.checkpoint)
+    def __init__(self, config: ColBERTConfig, tok):
+        self.tok = tok
 
         self.config = config
         self.query_maxlen = config.query_maxlen
         self.background_maxlen = 512 - self.query_maxlen + 1  # FIXME: Make this configurable
 
-        self.Q_marker_token, self.Q_marker_token_id = '[Q]', self.tok.convert_tokens_to_ids('[unused0]')
+        self.Q_marker_token = '[Q]'
+        if '[unused0]' in self.tok.vocab:
+            self.Q_marker_token_id = self.tok.convert_tokens_to_ids('[unused0]')
+        else:
+            self.Q_marker_token_id = self.tok.convert_tokens_to_ids(self.Q_marker_token)
         self.cls_token, self.cls_token_id = self.tok.cls_token, self.tok.cls_token_id
         self.sep_token, self.sep_token_id = self.tok.sep_token, self.tok.sep_token_id
         self.mask_token, self.mask_token_id = self.tok.mask_token, self.tok.mask_token_id
 
-        assert self.Q_marker_token_id == 1 and self.mask_token_id == 103
         self.used = False
 
     def tokenize(self, batch_text, add_special_tokens=False):

--- a/colbert/training/lazy_batcher.py
+++ b/colbert/training/lazy_batcher.py
@@ -3,6 +3,7 @@ import ujson
 
 from functools import partial
 from colbert.infra.config.config import ColBERTConfig
+from colbert.modeling.hf_colbert import HF_ColBERT
 from colbert.utils.utils import print_message, zipstar
 from colbert.modeling.tokenization import QueryTokenizer, DocTokenizer, tensorize_triples
 from colbert.evaluation.loaders import load_collection
@@ -19,8 +20,10 @@ class LazyBatcher():
         self.bsize, self.accumsteps = config.bsize, config.accumsteps
         self.nway = config.nway
 
-        self.query_tokenizer = QueryTokenizer(config)
-        self.doc_tokenizer = DocTokenizer(config)
+        tok = HF_ColBERT.raw_tokenizer_from_pretrained(config.checkpoint)
+        tok.add_tokens(["[Q]", "[D]"], special_tokens=True)
+        self.query_tokenizer = QueryTokenizer(config, tok)
+        self.doc_tokenizer = DocTokenizer(config, tok)
         self.tensorize_triples = partial(tensorize_triples, self.query_tokenizer, self.doc_tokenizer)
         self.position = 0
 


### PR DESCRIPTION
Not all tokenizers of pretrained models contain unused tokens in their vocabulary. This PR uses the unused if the tokenizer has these (to not break compatbility with pretrained ColBERT models) and otherwise sets special tokens '[D]' and '[Q]' if it doesn't have unused tokens.