### PR TITLE
Bugfix: In IndexUpdater, cast pids to Int before saving

### DIFF
--- a/colbert/index_updater.py
+++ b/colbert/index_updater.py
@@ -390,7 +390,7 @@ class IndexUpdater:
         assert sum(new_ivf_lengths) == len(new_ivf)
 
         # Replace the current ivf with new_ivf
-        self.curr_ivf = torch.tensor(new_ivf)
+        self.curr_ivf = torch.tensor(new_ivf, dtype=torch.int32)
         self.curr_ivf_lengths = torch.tensor(new_ivf_lengths)
 
     def _write_to_last_chunk(self, pid_start, pid_end, emb_start, emb_end):


### PR DESCRIPTION
I get an error while using IndexUpdater. This PR fixes it. 

Here's the minimal example script
```python
import os
from pathlib import Path

from colbert import Indexer, Searcher, IndexUpdater
from colbert.infra import ColBERTConfig, Run, RunConfig

old_books = [
    "The Adventures of Sherlock Holmes",
    "The Adventures of Tom Sawyer",
    "The Adventures of Huckleberry Finn",
]

modern_books = [
    "The song of ice and fire"*10,
    "Harry Potter and the Sorcerer's Stone"*10,
    "The Hunger Games"*10,
    "The Fellowship of the Ring"*10,
    "The Two Towers",
    "The Return of the King",
    "The Hobbit",
    "The Lord of the Rings",
    "The Hitchhiker's Guide to the Galaxy",
    "Seventy-Seven Clocks",
    "I, Robot",
    "Life, the Universe and Everything",
]

new_index = "tiny_index"

# Download the colbert model to this path
colbert_checkpoint = "colbertv2.0/"
if __name__ == "__main__":
    with Run().context(
        RunConfig(
            nranks=1,
            root=new_index,
            experiment="",
        )
    ):
        config = ColBERTConfig(nbits=2, root=new_index, doc_maxlen=100)
        indexer = Indexer(checkpoint=colbert_checkpoint, config=config)

        indexer.index(
            name="msmarco.nbits=2",
            collection=modern_books
        )

        searcher = Searcher(index="msmarco.nbits=2", config=config)
        config = ColBERTConfig(nbits=2, root=new_index, doc_maxlen=100)
        index_updater = IndexUpdater(
            config=config, searcher=searcher, checkpoint=colbert_checkpoint
        )

        index_updater.add(old_books)
        index_updater.persist_to_disk()
        results = searcher.search("Sherlock", 3)
        print(results)
```

Leads to the following error

```
Traceback (most recent call last):
  File "test_incremental_build_minimal.py", line 79, in <module>
    results = searcher.search("Sherlock", 3)
  File ".../ColBERT/colbert/searcher.py", line 61, in search
    return self.dense_search(Q, k, filter_fn=filter_fn)
  File ".../ColBERT/colbert/searcher.py", line 108, in dense_search
    pids, scores = self.ranker.rank(self.config, Q, filter_fn=filter_fn)
  File ".../ColBERT/colbert/search/index_storage.py", line 84, in rank
    scores, pids = self.score_pids(config, Q, pids, centroid_scores)
  File ".../ColBERT/colbert/search/index_storage.py", line 142, in score_pids
    pids = IndexScorer.filter_pids(
RuntimeError: expected scalar type Int but found Long
```

This PR fixes this issue, resulting in the following output
```
([10, 6, 13], [1, 2, 3], [9.62167739868164, 8.728744506835938, 8.65077018737793])
```