### PR TITLE
Indexing in-memory documents

### DIFF
--- a/colbert/indexer.py
+++ b/colbert/indexer.py
@@ -55,10 +55,10 @@ class Indexer:
 
         return deleted
 
-    def index(self, name, collection, overwrite=False):
+    def index(self, name, collection, collection_name=None, overwrite=False):
         assert overwrite in [True, False, 'reuse', 'resume']
 
-        self.configure(collection=collection, index_name=name, resume=overwrite=='resume')
+        self.configure(collection=collection_name or collection, index_name=name, resume=overwrite=='resume')
         self.configure(bsize=64, partitions=None)
 
         self.index_path = self.config.index_path_

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -33,8 +33,7 @@ class Searcher:
         self.checkpoint_config = ColBERTConfig.load_from_checkpoint(self.checkpoint)
         self.config = ColBERTConfig.from_existing(self.checkpoint_config, self.index_config, initial_config)
 
-        self.collection = Collection.cast(collection or self.config.collection)
-        self.configure(checkpoint=self.checkpoint, collection=self.collection)
+        self.configure(checkpoint=self.checkpoint)
 
         self.checkpoint = Checkpoint(self.checkpoint, colbert_config=self.config)
         use_gpu = self.config.total_visible_gpus > 0


### PR DESCRIPTION
I wanted to index a collection from in-memory documents. The collection loader already supports passing in-memory documents, the only issue was that the config would store and save the entire collection as well. To prevent this, I added a flag to the index function which allows specifying a collection name. The collection name is then saved instead of the in-memory collection. To make searching work, it was now also necessary to remove loading the collection before searching (since the collection config option now isn't a path but the collection name). As far as I can tell, loading the entire collection before searching is completely unecessary anyway and searching works perfectly fine without loading the collection beforehand.