### PR TITLE
Make class DefaultVal hashable to ensure compatibility with Python 3.11 dataclasses package

### DIFF
--- a/colbert/infra/config/core_config.py
+++ b/colbert/infra/config/core_config.py
@@ -14,7 +14,12 @@ from utility.utils.save_metadata import get_metadata_only
 @dataclass
 class DefaultVal:
     val: Any
+    
+    def __hash__(self):
+        return hash(repr(self.val))
 
+    def __eq__(self, other):
+        self.val == other.val
 
 @dataclass
 class CoreConfig:


### PR DESCRIPTION
Changes:
- Update class DefaultVal to implement __hash__ method to make it hashable, ensuring compatibility with the dataclasses package in Python 3.11.

Description:
- This pull request makes `class DefaultVal` hashable, allowing it to be compatible with the Python 3.11 `dataclasses` package. Without this change, a ValueError is raised when attempting to wrap a class that uses `DefaultVal` with the Python 3.11 `dataclass`. The issue was identified in the codes from [Baleen repository](https://github.com/stanford-futuredata/Baleen).

Here is an example of the exception that occurs without this fix:
<img width="926" alt="image" src="https://user-images.githubusercontent.com/106138715/236658860-990e3ad0-13ea-41c2-94c0-e60b7218efbd.png">