### PR TITLE
Add support for full-length searching

### DIFF
--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -40,13 +40,13 @@ class Checkpoint(ColBERT):
 
                 return D
 
-    def queryFromText(self, queries, bsize=None, to_cpu=False, context=None):
+    def queryFromText(self, queries, bsize=None, to_cpu=False, context=None, full_length_search=False):
         if bsize:
-            batches = self.query_tokenizer.tensorize(queries, context=context, bsize=bsize)
+            batches = self.query_tokenizer.tensorize(queries, context=context, bsize=bsize, full_length_search=full_length_search)
             batches = [self.query(input_ids, attention_mask, to_cpu=to_cpu) for input_ids, attention_mask in batches]
             return torch.cat(batches)
 
-        input_ids, attention_mask = self.query_tokenizer.tensorize(queries, context=context)
+        input_ids, attention_mask = self.query_tokenizer.tensorize(queries, context=context, full_length_search=full_length_search)
         return self.query(input_ids, attention_mask)
 
     def docFromText(self, docs, bsize=None, keep_dims=True, to_cpu=False, showprogress=False, return_tokens=False):

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -47,24 +47,24 @@ class Searcher:
     def configure(self, **kw_args):
         self.config.configure(**kw_args)
 
-    def encode(self, text: TextQueries):
+    def encode(self, text: TextQueries, full_length_search=False):
         queries = text if type(text) is list else [text]
         bsize = 128 if len(queries) > 128 else None
 
         self.checkpoint.query_tokenizer.query_maxlen = self.config.query_maxlen
-        Q = self.checkpoint.queryFromText(queries, bsize=bsize, to_cpu=True)
+        Q = self.checkpoint.queryFromText(queries, bsize=bsize, to_cpu=True, full_length_search=full_length_search)
 
         return Q
 
-    def search(self, text: str, k=10, filter_fn=None):
-        Q = self.encode(text)
+    def search(self, text: str, k=10, filter_fn=None, full_length_search=False):
+        Q = self.encode(text, full_length_search=full_length_search)
         return self.dense_search(Q, k, filter_fn=filter_fn)
 
-    def search_all(self, queries: TextQueries, k=10, filter_fn=None):
+    def search_all(self, queries: TextQueries, k=10, filter_fn=None, full_length_search=False):
         queries = Queries.cast(queries)
         queries_ = list(queries.values())
 
-        Q = self.encode(queries_)
+        Q = self.encode(queries_, full_length_search=full_length_search)
 
         return self._search_all_Q(queries, Q, k, filter_fn=filter_fn)
 


### PR DESCRIPTION
This adds the ability to search with queries that exceed the default query_maxlen.

Note: It only works for single inference.  Doing this for batched inference requires significantly deeper changes to the codebase.
