### PR TITLE
[IndexUpdater] Minimizing calls to torch.Tensor.tolist() and torch.Tensor() for performance optimization

### DIFF
--- a/colbert/index_updater.py
+++ b/colbert/index_updater.py
@@ -120,11 +120,12 @@ class IndexUpdater:
 
         # Build partitions for each pid and update IndexUpdater's current ivf
         start = 0
+        ivf = self.curr_ivf.tolist()
         for doclen in doclens:
             end = start + doclen
             codes = compressed_embs.codes[start:end]
             partitions, _ = self._build_passage_partitions(codes)
-            self._add_pid_to_ivf(partitions, curr_pid)
+            ivf = self._add_pid_to_ivf(partitions, curr_pid, ivf)
 
             start = end
             curr_pid += 1
@@ -378,7 +379,7 @@ class IndexUpdater:
         partitions, ivf_lengths = values.unique_consecutive(return_counts=True)
         return partitions, ivf_lengths
 
-    def _add_pid_to_ivf(self, partitions, pid):
+    def _add_pid_to_ivf(self, partitions, pid, old_ivf):
         """
         Helper function for IndexUpdater.add()
 
@@ -391,7 +392,6 @@ class IndexUpdater:
         """
         new_ivf = []
         new_ivf_lengths = []
-        old_ivf = self.curr_ivf.tolist()
         old_ivf_lengths = self.curr_ivf_lengths.tolist()
 
         partitions_runner = 0
@@ -417,6 +417,8 @@ class IndexUpdater:
         # Replace the current ivf with new_ivf
         self.curr_ivf = torch.tensor(new_ivf, dtype=self.curr_ivf.dtype)
         self.curr_ivf_lengths = torch.tensor(new_ivf_lengths, dtype=self.curr_ivf_lengths.dtype)
+
+        return new_ivf
 
     def _write_to_last_chunk(self, pid_start, pid_end, emb_start, emb_end):
         # Helper function for IndexUpdater.persist_to_disk()

--- a/colbert/index_updater.py
+++ b/colbert/index_updater.py
@@ -121,16 +121,21 @@ class IndexUpdater:
         # Build partitions for each pid and update IndexUpdater's current ivf
         start = 0
         ivf = self.curr_ivf.tolist()
+        ivf_lengths = self.curr_ivf_lengths.tolist()
         for doclen in doclens:
             end = start + doclen
             codes = compressed_embs.codes[start:end]
             partitions, _ = self._build_passage_partitions(codes)
-            ivf = self._add_pid_to_ivf(partitions, curr_pid, ivf)
+            ivf, ivf_lengths = self._add_pid_to_ivf(partitions, curr_pid, ivf, ivf_lengths)
 
             start = end
             curr_pid += 1
-
+        
         assert start == sum(doclens)
+
+        # Replace the current ivf with new_ivf
+        self.curr_ivf = torch.tensor(ivf, dtype=self.curr_ivf.dtype)
+        self.curr_ivf_lengths = torch.tensor(ivf_lengths, dtype=self.curr_ivf_lengths.dtype)
 
         # Update new ivf in searcher
         new_ivf_tensor = StridedTensor(
@@ -379,7 +384,7 @@ class IndexUpdater:
         partitions, ivf_lengths = values.unique_consecutive(return_counts=True)
         return partitions, ivf_lengths
 
-    def _add_pid_to_ivf(self, partitions, pid, old_ivf):
+    def _add_pid_to_ivf(self, partitions, pid, old_ivf, old_ivf_lengths):
         """
         Helper function for IndexUpdater.add()
 
@@ -392,7 +397,6 @@ class IndexUpdater:
         """
         new_ivf = []
         new_ivf_lengths = []
-        old_ivf_lengths = self.curr_ivf_lengths.tolist()
 
         partitions_runner = 0
         ivf_runner = 0
@@ -414,11 +418,7 @@ class IndexUpdater:
         assert ivf_runner == len(old_ivf)
         assert sum(new_ivf_lengths) == len(new_ivf)
 
-        # Replace the current ivf with new_ivf
-        self.curr_ivf = torch.tensor(new_ivf, dtype=self.curr_ivf.dtype)
-        self.curr_ivf_lengths = torch.tensor(new_ivf_lengths, dtype=self.curr_ivf_lengths.dtype)
-
-        return new_ivf
+        return new_ivf, new_ivf_lengths
 
     def _write_to_last_chunk(self, pid_start, pid_end, emb_start, emb_end):
         # Helper function for IndexUpdater.persist_to_disk()


### PR DESCRIPTION
For a huge index, self.curr_ivf.tolist() takes a long time. Calling it only once per IndexUpdater.update_searcher call instead of per pid improves the performance significantly.