### PR TITLE
Adding support for reranker and other utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ For fast retrieval, indexing precomputes the ColBERT representations of passages
 
 Example usage:
 
-```
+```python
 from colbert.infra import Run, RunConfig, ColBERTConfig
 from colbert import Indexer
 
@@ -120,7 +120,7 @@ if __name__=='__main__':
 
 We typically recommend that you use ColBERT for **end-to-end** retrieval, where it directly finds its top-k passages from the full collection:
 
-```
+```python
 from colbert.data import Queries
 from colbert.infra import Run, RunConfig, ColBERTConfig
 from colbert import Searcher
@@ -154,7 +154,7 @@ Training requires a JSONL triples file with a `[qid, pid+, pid-]` list per line.
 
 Example usage (training on 4 GPUs):
 
-```
+```python
 from colbert.infra import Run, RunConfig, ColBERTConfig
 from colbert import Trainer
 
@@ -175,6 +175,38 @@ if __name__=='__main__':
         checkpoint_path = trainer.train()
 
         print(f"Saved checkpoint to {checkpoint_path}...")
+```
+
+## Reranking
+
+We provide an easy to use interface that can be used for reranking and rank fusion for multiple rankings. `Reranker` takes Queries, Collection and Ranking as input and you can get the reranking by passing the checkpoint to the reranker model. Here is an example:-
+
+```python
+from colbert.data.ranking import Ranking
+from colbert.data.queries import Queries
+from colbert.data.collection import Collection
+
+from colbert.infra import Run, RunConfig
+from colbert.reranker import Reranker
+
+if __name__=='__main__':
+    with Run().context(RunConfig(
+        nranks=number_of_gpu_devices,
+        root="path/to/experiments", 
+        experiment="awesome_experiment", 
+        name='awesome_run_name'
+    )):
+        ranking = Ranking(path = 'path/to/ranking/file')
+        queries = Queries(path = 'path/to/query/file')
+        collection = Collection(path = 'path/to/collection/file')
+
+        reranker = Reranker(ranking=ranking, queries=queries, collection=collection)
+        score_file = reranker.rerank(checkpoint)
+```
+
+Additionally you can use ranx to fuse multiple ranking together too! Just pass the rankings and fusion strategy and the rest will be taken care of:-
+```python
+
 ```
 
 ## Running a lightweight ColBERTv2 server

--- a/colbert/data/examples.py
+++ b/colbert/data/examples.py
@@ -1,17 +1,19 @@
-from colbert.infra.run import Run
 import os
 import ujson
+import random
 
+from colbert.infra.run import Run
 from colbert.utils.utils import print_message
 from colbert.infra.provenance import Provenance
 from utility.utils.save_metadata import get_metadata_only
 
 
 class Examples:
-    def __init__(self, path=None, data=None, nway=None, provenance=None):
+    def __init__(self, path=None, data=None, nway=None, provenance=None, shuffle=False):
         self.__provenance = provenance or path or Provenance()
         self.nway = nway
         self.path = path
+        self.shuffle = shuffle
         self.data = data or self._load_file(path)
 
     def provenance(self):
@@ -28,7 +30,10 @@ class Examples:
             for line in f:
                 example = ujson.loads(line)[:nway]
                 examples.append(example)
-
+        
+        if self.shuffle:
+            random.shuffle(examples)
+        
         return examples
 
     def tolist(self, rank=None, nranks=None):
@@ -41,7 +46,7 @@ class Examples:
 
         if rank or nranks:
             assert rank in range(nranks), (rank, nranks)
-            return [self.data[idx] for idx in range(0, len(self.data), nranks)]  # if line_idx % nranks == rank
+            return [self.data[idx + rank] for idx in range(0, len(self.data), nranks) if idx + rank < len(self.data)]  # if line_idx % nranks == rank
 
         return list(self.data)
 
@@ -68,12 +73,12 @@ class Examples:
         return output_path
 
     @classmethod
-    def cast(cls, obj, nway=None):
+    def cast(cls, obj, nway=None, shuffle=False):
         if type(obj) is str:
-            return cls(path=obj, nway=nway)
+            return cls(path=obj, nway=nway, shuffle=shuffle)
 
         if isinstance(obj, list):
-            return cls(data=obj, nway=nway)
+            return cls(data=obj, nway=nway, shuffle=shuffle)
 
         if type(obj) is cls:
             assert nway is None, nway

--- a/colbert/data/queries.py
+++ b/colbert/data/queries.py
@@ -9,8 +9,12 @@ from colbert.evaluation.loaders import load_queries
 
 
 class Queries:
-    def __init__(self, path=None, data=None):
+    def __init__(self, path=None, data=None, query_id_key='id', query_key='query', include_body=True, body_char_limit=1000):
         self.path = path
+        self.query_key = query_key
+        self.query_id_key = query_id_key
+        self.include_body = include_body
+        self.body_char_limit = body_char_limit
 
         if data:
             assert isinstance(data, dict), type(data)
@@ -37,7 +41,7 @@ class Queries:
 
         for qid, content in data.items():
             if isinstance(content, dict):
-                self.data[qid] = content['question']
+                self.data[qid] = content[self.query_key]
                 self._qas[qid] = content
             else:
                 self.data[qid] = content
@@ -48,7 +52,7 @@ class Queries:
         return True
 
     def _load_file(self, path):
-        if not path.endswith('.json'):
+        if not (path.endswith('.json') or path.endswith('.jsonl')):
             self.data = load_queries(path)
             return True
         
@@ -60,9 +64,12 @@ class Queries:
             for line in f:
                 qa = ujson.loads(line)
 
-                assert qa['qid'] not in self.data
-                self.data[qa['qid']] = qa['question']
-                self._qas[qa['qid']] = qa
+                assert qa[self.query_id_key] not in self.data
+                if self.include_body and 'body' in qa:
+                    self.data[qa[self.query_id_key]] = qa[self.query_key] + '|' + qa['body'][:self.body_char_limit]
+                else:
+                    self.data[qa[self.query_id_key]] = qa[self.query_key]
+                self._qas[qa[self.query_id_key]] = qa
 
         return self.data
 
@@ -98,7 +105,7 @@ class Queries:
 
         with open(new_path, 'w') as f:
             for qid, qa in self._qas.items():
-                qa['qid'] = qid
+                qa[self.query_id_key] = qid
                 f.write(ujson.dumps(qa) + '\n')
 
     def _load_tsv(self, path):

--- a/colbert/distillation/hf_scorers/__init__.py
+++ b/colbert/distillation/hf_scorers/__init__.py
@@ -1,0 +1,2 @@
+from .bge_reranker import BGERerankerScorer
+from .bge_large import BGELargeV15Scorer

--- a/colbert/distillation/hf_scorers/base.py
+++ b/colbert/distillation/hf_scorers/base.py
@@ -1,0 +1,31 @@
+from colbert.infra import Run
+from colbert.parameters import DEVICE
+from colbert.utils.utils import flatten
+from colbert.infra.launcher import Launcher
+
+class BaseHFScorer:
+    def __init__(self, queries, collection, model, bsize=32, maxlen=180):
+        self.queries = queries
+        self.collection = collection
+        self.model = model
+
+        self.device = DEVICE
+        self.bsize = bsize
+        self.maxlen = maxlen
+
+    def launch(self, qids, pids):
+        launcher = Launcher(self._score_pairs_process, return_all=True)
+        outputs = launcher.launch(Run().config, qids, pids)
+
+        return flatten(outputs)
+
+    def _score_pairs_process(self, config, qids, pids):
+        assert len(qids) == len(pids), (len(qids), len(pids))
+        share = 1 + len(qids) // config.nranks
+        offset = config.rank * share
+        endpos = (1 + config.rank) * share
+
+        return self.score(qids[offset:endpos], pids[offset:endpos], show_progress=(config.rank < 1))
+
+    def score(self, qids, pids):
+        raise NotImplementedError

--- a/colbert/distillation/hf_scorers/bge_large.py
+++ b/colbert/distillation/hf_scorers/bge_large.py
@@ -1,0 +1,63 @@
+import torch
+import tqdm
+from transformers import AutoTokenizer, AutoModel
+
+from colbert.infra import Run
+from colbert.distillation.hf_scorers.base import BaseHFScorer
+
+class BGELargeV15Scorer(BaseHFScorer):
+    def __init__(self, queries, collection, model, bsize=32, maxlen=180, query_instruction=None):
+        super().__init__(queries, collection, model, bsize=bsize, maxlen=maxlen)
+
+        self.query_instruction = query_instruction or "Represent this sentence for searching relevant passages:"
+
+    def score(self, qids, pids, show_progress=False):
+        tokenizer = AutoTokenizer.from_pretrained(self.model)
+        model = AutoModel.from_pretrained(self.model).to(self.device)
+        
+        assert len(qids) == len(pids), (len(qids), len(pids))
+
+        scores = []
+
+        model.eval()
+        with torch.inference_mode():
+            with torch.cuda.amp.autocast():
+                for offset in tqdm.tqdm(range(0, len(qids), self.bsize), disable=(not show_progress)):
+                    endpos = offset + self.bsize
+
+                    if self.query_instruction is None:
+                        queries_ = [self.queries[qid] for qid in qids[offset:endpos]]
+                    else:
+                        queries_ = [self.query_instruction + self.queries[qid] for qid in qids[offset:endpos]]
+                    
+                    try:
+                        passages_ = [self.collection[pid] for pid in pids[offset:endpos]]
+                    except:
+                        print(pids[offset:endpos])
+                        raise Exception
+
+                    query_features = tokenizer(queries_, padding='longest', truncation=True,
+                                            return_tensors='pt', max_length=self.maxlen).to(self.device)
+
+                    passage_features = tokenizer(passages_, padding='longest', truncation=True,
+                                            return_tensors='pt', max_length=self.maxlen).to(self.device)
+
+                    query_embeddings = model(**query_features)
+                    query_embeddings = query_embeddings[0][:, 0]
+                    query_embeddings = torch.nn.functional.normalize(query_embeddings, p=2, dim=1)
+
+                    passage_embeddings = model(**passage_features)
+                    passage_embeddings = passage_embeddings[0][:, 0]
+                    passage_embeddings = torch.nn.functional.normalize(passage_embeddings, p=2, dim=1)
+
+                    batch_scores = torch.einsum('nd,nd->n', query_embeddings, passage_embeddings)
+                    
+                    scores.append(batch_scores)
+
+
+        scores = torch.cat(scores)
+        scores = scores.tolist()
+
+        Run().print(f'Returning with {len(scores)} scores')
+
+        return scores

--- a/colbert/distillation/hf_scorers/bge_reranker.py
+++ b/colbert/distillation/hf_scorers/bge_reranker.py
@@ -1,0 +1,54 @@
+import torch
+import tqdm
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+from colbert.infra import Run
+from colbert.distillation.hf_scorers.base import BaseHFScorer
+
+class BGERerankerScorer(BaseHFScorer):
+    def __init__(self, queries, collection, model, bsize=32, maxlen=180, query_instruction=None):
+        super().__init__(queries, collection, model, bsize=bsize, maxlen=maxlen)
+
+        self.query_instruction = query_instruction
+
+    def score(self, qids, pids, show_progress=False):
+        tokenizer = AutoTokenizer.from_pretrained(self.model)
+        model = AutoModelForSequenceClassification.from_pretrained(self.model).cuda()
+        
+        assert len(qids) == len(pids), (len(qids), len(pids))
+
+        scores = []
+
+        model.eval()
+        with torch.inference_mode():
+            with torch.cuda.amp.autocast():
+                for offset in tqdm.tqdm(range(0, len(qids), self.bsize), disable=(not show_progress)):
+                    endpos = offset + self.bsize
+
+                    if self.query_instruction is None:
+                        queries_ = [self.queries[qid] for qid in qids[offset:endpos]]
+                    else:
+                        queries_ = [self.query_instruction + self.queries[qid] for qid in qids[offset:endpos]]
+                    
+                    try:
+                        passages_ = [self.collection[pid] for pid in pids[offset:endpos]]
+                    except:
+                        print(pids[offset:endpos])
+                        raise Exception
+                    
+                    pairs = [[q,p] for q, p in zip(queries_, passages_)]
+
+                    features = tokenizer(pairs, padding='longest', truncation=True,
+                                return_tensors='pt', max_length=self.maxlen).to(self.device)
+
+                    batch_scores = model(**features, return_dict=True).logits.view(-1, ).float()
+
+                    scores.append(batch_scores)
+
+
+        scores = torch.cat(scores)
+        scores = scores.tolist()
+
+        Run().print(f'Returning with {len(scores)} scores')
+
+        return scores

--- a/colbert/distillation/scorer.py
+++ b/colbert/distillation/scorer.py
@@ -1,25 +1,31 @@
-import torch
 import tqdm
-
+import torch
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
-from colbert.infra.launcher import Launcher
-from colbert.infra import Run, RunConfig
-from colbert.modeling.reranker.electra import ElectraReranker
+from colbert.infra import Run
 from colbert.utils.utils import flatten
+from colbert.infra.launcher import Launcher
+
+from colbert.modeling.reranker.electra import ElectraReranker
+from colbert.modeling.reranker.codeT5p import CodeT5pReranker
+from colbert.modeling.reranker.deberta import DebertaV2Reranker
+from colbert.modeling.reranker.codet5p_encdec import CodeT5pEncDecReranker
 
 
 DEFAULT_MODEL = 'cross-encoder/ms-marco-MiniLM-L-6-v2'
 
 
 class Scorer:
-    def __init__(self, queries, collection, model=DEFAULT_MODEL, maxlen=180, bsize=256):
+    def __init__(self, queries, collection, model=DEFAULT_MODEL, maxlen=180, bsize=256, model_type="encoder_only"):
         self.queries = queries
         self.collection = collection
         self.model = model
 
         self.maxlen = maxlen
         self.bsize = bsize
+        self.model_type = model_type
+
+        self.device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
 
     def launch(self, qids, pids):
         launcher = Launcher(self._score_pairs_process, return_all=True)
@@ -37,7 +43,20 @@ class Scorer:
 
     def _score_pairs(self, qids, pids, show_progress=False):
         tokenizer = AutoTokenizer.from_pretrained(self.model)
-        model = AutoModelForSequenceClassification.from_pretrained(self.model).cuda()
+
+        if self.model == DEFAULT_MODEL:
+            model = AutoModelForSequenceClassification.from_pretrained(self.model).to(self.device)
+        else:
+            if self.model_type == "encoder-only":
+                if 'codet5' in str(self.model):
+                    model = CodeT5pReranker.from_pretrained(self.model).to(self.device)
+                elif 'deberta' in str(self.model):
+                    model = DebertaV2Reranker.from_pretrained(self.model).to(self.device)
+                else:
+                    model = ElectraReranker.from_pretrained(self.model).to(self.device)
+            else:
+                if 't5' in str(self.model):
+                    model = CodeT5pEncDecReranker(self.model).to(self.device)
 
         assert len(qids) == len(pids), (len(qids), len(pids))
 
@@ -50,12 +69,19 @@ class Scorer:
                     endpos = offset + self.bsize
 
                     queries_ = [self.queries[qid] for qid in qids[offset:endpos]]
-                    passages_ = [self.collection[pid] for pid in pids[offset:endpos]]
+                    try:
+                        passages_ = [self.collection[pid] for pid in pids[offset:endpos]]
+                    except:
+                        print(pids[offset:endpos])
+                        raise Exception
 
                     features = tokenizer(queries_, passages_, padding='longest', truncation=True,
-                                            return_tensors='pt', max_length=self.maxlen).to(model.device)
+                                            return_tensors='pt', max_length=self.maxlen).to(self.device)
 
-                    scores.append(model(**features).logits.flatten())
+                    if self.model == DEFAULT_MODEL:
+                        scores.append(model(**features).logits.flatten())
+                    else:
+                        scores.append(model(features))
 
         scores = torch.cat(scores)
         scores = scores.tolist()
@@ -66,3 +92,16 @@ class Scorer:
 
 
 # LONG-TERM TODO: This can be sped up by sorting by length in advance.
+# def _score_pairs(self, qids, pids, show_progress=False):
+#     tokenizer = AutoTokenizer.from_pretrained(self.model)
+
+#     pairs_with_lengths = [(qid, pid, len(self.queries[qid])) for qid, pid in zip(qids, pids)]
+#     index_map = sorted(range(len(pairs_with_lengths)), key=pairs_with_lengths.__getitem__)
+#     pairs_with_lengths.sort(key=lambda x: x[2])
+#     qids, pids, _ = zip(*pairs_with_lengths)
+
+#     [ORIGINAL CODE]
+
+#     scores = [x for _, x in sorted(zip(index_map, scores))]
+
+#     return scores

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -152,6 +152,10 @@ class TrainingSettings:
     ignore_scores: bool = DefaultVal(False)
 
     model_name: str = DefaultVal(None) # DefaultVal('bert-base-uncased')
+    
+    model_type: str = DefaultVal('encoder-only')
+
+    shuffle_triples: bool = DefaultVal(False)
 
 @dataclass
 class IndexingSettings:

--- a/colbert/modeling/reranker/codeT5p.py
+++ b/colbert/modeling/reranker/codeT5p.py
@@ -1,0 +1,47 @@
+import copy
+import torch.nn as nn
+
+from transformers import T5PreTrainedModel, T5EncoderModel, AutoTokenizer
+from transformers.models.t5.modeling_t5 import T5Stack
+
+class CodeT5pReranker(T5PreTrainedModel):
+    """
+        Shallow wrapper around HuggingFace transformers. All new parameters should be defined at this level.
+        
+        This makes sure `{from,save}_pretrained` and `init_weights` are applied to new parameters correctly.
+    """
+    _keys_to_ignore_on_load_unexpected = [r"cls"]
+
+    def __init__(self, config):
+        super().__init__(config)
+
+        print(config)
+
+        self.model_dim = config.d_model
+
+        self.shared = nn.Embedding(config.vocab_size, config.d_model)
+
+        encoder_config = copy.deepcopy(config)
+        encoder_config.is_decoder = False
+        encoder_config.use_cache = False
+        encoder_config.is_encoder_decoder = False
+        self.encoder = T5Stack(encoder_config, self.shared)
+
+        self.linear = nn.Linear(config.hidden_size, 1)
+        self.raw_tokenizer = AutoTokenizer.from_pretrained(config._name_or_path)
+
+        self.init_weights()
+
+    def forward(self, encoding):
+        outputs = self.encoder(encoding.input_ids,
+                               attention_mask=encoding.attention_mask)[0]
+
+        scores = self.linear(outputs[:, 0]).squeeze(-1)
+
+        return scores
+    
+    def save(self, path):
+        assert not path.endswith('.dnn'), f"{path}: We reserve *.dnn names for the deprecated checkpoint format."
+
+        self.save_pretrained(path)
+        self.raw_tokenizer.save_pretrained(path)

--- a/colbert/modeling/reranker/codet5p_encdec.py
+++ b/colbert/modeling/reranker/codet5p_encdec.py
@@ -1,0 +1,34 @@
+import torch.nn as nn
+
+from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+
+class CodeT5pEncDecReranker(nn.Module):
+
+    def __init__(self, checkpoint):
+        super().__init__()
+
+        self.codet5p = AutoModelForSeq2SeqLM.from_pretrained(checkpoint, trust_remote_code=True)
+        self.raw_tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+
+        self.GOOD_TOKEN = self.raw_tokenizer.encode('good')[0]
+
+    def forward(self, encoding, decoder_input_ids=None):
+        # If decoder_input_ids are not provided, use input_ids shifted by one token
+        if decoder_input_ids is None:
+            decoder_input_ids = encoding.input_ids[:, 1:2]
+
+        # Get logits from the model
+        outputs = self.codet5p(input_ids=encoding.input_ids,
+                            attention_mask=encoding.attention_mask,
+                            decoder_input_ids=decoder_input_ids)
+
+        logits = outputs.logits
+        scores = logits[:, -1, self.GOOD_TOKEN]  # Assuming you want the score of the last token position
+
+        return scores
+
+    def save(self, path):
+        assert not path.endswith('.dnn'), f"{path}: We reserve *.dnn names for the deprecated checkpoint format."
+
+        self.codet5p.save_pretrained(path)
+        self.raw_tokenizer.save_pretrained(path)

--- a/colbert/modeling/reranker/deberta.py
+++ b/colbert/modeling/reranker/deberta.py
@@ -1,0 +1,37 @@
+import torch.nn as nn
+
+from transformers import DebertaV2PreTrainedModel, DebertaV2Model, AutoTokenizer
+
+class DebertaV2Reranker(DebertaV2PreTrainedModel):
+    """
+        Shallow wrapper around HuggingFace transformers. All new parameters should be defined at this level.
+        
+        This makes sure `{from,save}_pretrained` and `init_weights` are applied to new parameters correctly.
+    """
+    _keys_to_ignore_on_load_unexpected = [r"cls"]
+
+    def __init__(self, config):
+        super().__init__(config)
+        config.max_position_embeddings = 1024
+        print(config)
+
+        self.deberta = DebertaV2Model(config)
+        self.linear = nn.Linear(config.hidden_size, 1)
+        self.raw_tokenizer = AutoTokenizer.from_pretrained(config._name_or_path)
+
+        self.init_weights()
+
+    def forward(self, encoding):
+        outputs = self.deberta(encoding.input_ids,
+                               attention_mask=encoding.attention_mask,
+                               token_type_ids=encoding.token_type_ids)[0]
+
+        scores = self.linear(outputs[:, 0]).squeeze(-1)
+
+        return scores
+    
+    def save(self, path):
+        assert not path.endswith('.dnn'), f"{path}: We reserve *.dnn names for the deprecated checkpoint format."
+
+        self.save_pretrained(path)
+        self.raw_tokenizer.save_pretrained(path)

--- a/colbert/reranker.py
+++ b/colbert/reranker.py
@@ -1,0 +1,125 @@
+import os
+import json
+import pandas as pd
+from typing import List
+from ranx import Run, fuse
+
+from colbert.utils.utils import print_message
+from colbert.infra.run import Run as ColbertRun
+from colbert.distillation.scorer import Scorer
+from colbert.distillation.ranking_scorer import RankingScorer
+
+class Reranker:
+    """
+        The Reranker class is responsible for reranking a given ranking.
+
+        Example:-
+            with Run().context(RunConfig(
+                nranks=number_of_gpu_devices,
+                root="path/to/experiments", 
+                experiment="awesome_experiment", 
+                name='awesome_run_name'
+            )):
+                ranking = Ranking(path = 'path/to/ranking/file')
+                queries = Queries(path = 'path/to/query/file')
+                collection = Collection(path = 'path/to/collection/file')
+
+                reranker = Reranker(ranking=ranking, queries=queries, collection=collection)
+                score_file = reranker.rerank(checkpoint)
+    """
+
+    def __init__(self, ranking=None, queries=None, collection=None):
+        """
+            The constructor for the Reranker class. The Reranker class is responsible
+            for reranking a given set of queries and collections.
+        """
+        self.ranking = ranking
+        self.queries = queries
+        self.collection = collection
+
+
+    def rerank(self, checkpoint, model_type="encoder-only", bsize=32, maxlen=180):
+        """
+            The rerank method is responsible for reranking a given set of queries and collections.
+        """
+        print_message("#> Starting..")
+        scorer = Scorer(self.queries, self.collection, checkpoint, model_type=model_type, bsize=bsize, maxlen=maxlen)
+        rank_scorer = RankingScorer(scorer, self.ranking)
+
+        print(f">>> Generating on ckpt {checkpoint}")
+        
+        return rank_scorer.run()
+
+
+    def fuse_rankings(self, rankings: List[str], strategy: str, params:dict = None):
+        """
+            The fuse_rankings method is responsible for fusing a given set of rankings. The
+            strategy parameter is used to determine the fusion strategy to be used. The
+            strategy parameter can be any one supported by the ranx library.
+        """
+        print_message("#> Starting..")
+        
+        runs = []
+        for i, rank_file in enumerate(rankings):
+            assert os.path.exists(rank_file), f"Ranking file {rank_file} does not exist."
+            assert (rank_file.endswith('.tsv') or rank_file.endswith('.json')), f"Ranking file {rank_file} is not a tsv or json file."
+
+            if rank_file.endswith('.json'):
+                output_filename = f"rankings-{i+1}.tsv"
+                rank_file = self.convert_json_scores_to_tsv(rank_file, output_filename)
+
+            data = pd.read_csv(rank_file, sep = '\t', names=['qid', 'pid', 'rank', 'score'])
+            data = data.drop(['rank'], axis=1)
+            data['qid'] = data['qid'].map(str)
+            data['pid'] = data['pid'].map(str)
+            
+            run = Run.from_df(
+                df=data,
+                q_id_col="qid",
+                doc_id_col="pid",
+                score_col="score",
+            )
+            runs.append(run)
+
+        print_message("#> Fusing rankings..")
+
+        combined_run = fuse(
+            runs=runs,
+            method=strategy,
+            params=params
+        )
+
+        print_message("#> Saving fused ranking..")
+
+        with ColbertRun().open('ensemble_ranking.json', 'w') as f:
+            combined_run.save(f.name)
+            ensemble_ranking_path = f.name
+
+        print_message(f"#> Fusion complete. Saved fused ranking to {ensemble_ranking_path}")
+
+        return ensemble_ranking_path
+
+
+    def convert_json_scores_to_tsv(self, score_json:str, output_filename:str='rankings.tsv'):
+        assert os.path.exists(score_json), f"Score file {score_json} does not exist."
+        assert output_filename.endswith('.tsv'), f"Output filename {output_filename} is not a tsv file."
+
+        with ColbertRun().open(score_json, 'r') as f:
+            # Load the file line-by-line and attempt to parse each line as a JSON object
+            data_list = []
+            for line in f:
+                data_list.append(json.loads(line))
+
+        with ColbertRun().open(output_filename, 'w') as f:
+            for item in data_list:
+                qid = item[0]
+                scores = item[1]
+                
+                scores.sort(reverse=True)  # Sort scores in descending order
+                
+                for rank, (score, pid) in enumerate(scores, start=1):
+                    f.write(f"{qid}\t{pid}\t{rank}\t{score}\n")
+            
+            output_path = f.name
+
+        return output_path

--- a/colbert/training/rerank_batcher.py
+++ b/colbert/training/rerank_batcher.py
@@ -23,7 +23,7 @@ class RerankBatcher():
         self.tokenizer = RerankerTokenizer(total_maxlen=config.doc_maxlen, base=config.checkpoint)
         self.position = 0
 
-        self.triples = Examples.cast(triples, nway=self.nway).tolist(rank, nranks)
+        self.triples = Examples.cast(triples, nway=self.nway, shuffle=config.shuffle_triples).tolist(rank, nranks)
         self.queries = Queries.cast(queries)
         self.collection = Collection.cast(collection)
 

--- a/colbert/training/training.py
+++ b/colbert/training/training.py
@@ -14,6 +14,9 @@ from colbert.parameters import DEVICE
 
 from colbert.modeling.colbert import ColBERT
 from colbert.modeling.reranker.electra import ElectraReranker
+from colbert.modeling.reranker.codeT5p import CodeT5pReranker
+from colbert.modeling.reranker.deberta import DebertaV2Reranker
+from colbert.modeling.reranker.codet5p_encdec import CodeT5pEncDecReranker
 
 from colbert.utils.utils import print_message
 from colbert.training.utils import print_progress, manage_checkpoints
@@ -47,7 +50,16 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
     if not config.reranker:
         colbert = ColBERT(name=config.checkpoint, colbert_config=config)
     else:
-        colbert = ElectraReranker.from_pretrained(config.checkpoint)
+        if config.model_type == "encoder-only":
+            if 't5' in str(config.checkpoint):
+                colbert = CodeT5pReranker.from_pretrained(config.checkpoint)
+            elif 'deberta' in str(config.checkpoint):
+                colbert = DebertaV2Reranker.from_pretrained(config.checkpoint)
+            else:
+                colbert = ElectraReranker.from_pretrained(config.checkpoint)
+        else:
+            if 't5' in str(config.checkpoint):
+                colbert = CodeT5pEncDecReranker(config.checkpoint)
 
     colbert = colbert.to(DEVICE)
     colbert.train()
@@ -84,6 +96,7 @@ def train(config: ColBERTConfig, triples, queries=None, collection=None):
 
     #     reader.skip_to_batch(start_batch_idx, checkpoint['arguments']['bsize'])
 
+    print("Starting training...")
     for batch_idx, BatchSteps in zip(range(start_batch_idx, config.maxsteps), reader):
         if (warmup_bert is not None) and warmup_bert <= batch_idx:
             set_bert_grad(colbert, True)

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
     ], 
     extras_require={
         'faiss-gpu': ['faiss-gpu>=1.7.0'],
-        'torch': ['torch==1.13.1']
+        'torch': ['torch==1.13.1'],
+        'ranx': ['ranx==0.3.16']
     }
 )

--- a/utility/evaluate/stack_overflow.py
+++ b/utility/evaluate/stack_overflow.py
@@ -1,0 +1,102 @@
+"""
+    Evaluate Stack Overflow Passages ranking.
+"""
+
+import json
+import pytrec_eval
+from argparse import ArgumentParser
+from colbert.utils.utils import print_message
+
+def main(args):
+    print_message(f"Stating evaluation for {args.distillation_score}..")
+    # Load qrels which is a json file
+    qrels = json.load(open(args.qrels, 'r'))
+    print_message("Loaded qrels ..")
+
+    score = {}
+    if args.distillation_score is not None:
+        # Load the file line-by-line and attempt to parse each line as a JSON object
+        data_list = []
+        with open(args.distillation_score, "r") as f:
+            for line in f:
+                data_list.append(json.loads(line))
+
+        # Process the loaded data to the desired format
+        for item in data_list:
+            qid = str(item[0])
+            scores = item[1]
+            pid_score_dict = {str(score[1]): score[0] for score in scores}
+            if qid in qrels.keys():
+                score[qid] = pid_score_dict
+
+        print_message("Loaded distillation scores ..")
+    
+    elif args.ranking:
+        with open(args.ranking, "r") as f:
+            for line in f:
+                qid, pid, _, points = line.strip().split("\t")
+
+                qid = str(qid)
+                pid = str(pid)
+                points = float(points)
+
+                if qid in qrels.keys():
+                    if qid not in score.keys():
+                        score[qid] = {}
+
+                    score[qid][str(pid)] = points
+    
+    elif args.ranx_score is not None:
+        # No need to load the file line-by-line and directly parse it as a JSON object
+        score = json.load(open(args.ranx_score, 'r'))
+
+        print_message("Loaded ranx scores ..")
+    
+    else:
+        raise ValueError("No score file provided. Make sure to provide either distillation score or ranx score in json format.")
+
+    # assert that the qrels keys is a subset of distillation scores keys
+    qrels_keys = set(qrels.keys())
+    score_keys = set(score.keys())
+
+    assert qrels_keys.issubset(score_keys), "qrels keys is not a subset of distillation scores keys"
+
+    print_message("#> Evaluating Success@k ..")
+    depth = [5, 10, 20, 100]
+
+    for k in depth:
+        success_at_k = 0
+        total_pids = 0
+        for qid in qrels.keys():
+            qrel_pids = set(qrels[qid].keys())
+            top_k_pids = sorted(score[qid].items(), key=lambda x: x[1], reverse=True)[:k]
+            top_k_pids = set([pid for pid, _ in top_k_pids])
+            
+            common_pids = qrel_pids.intersection(top_k_pids)
+            success_at_k += len(common_pids) > 0
+            total_pids += len(qrel_pids)
+        success_at_k = success_at_k / len(qrels.keys()) if total_pids > 0 else 0
+        print_message(f"#> Success@{k}: {success_at_k}")    
+    
+    print_message("#> Evaluating Recall ..")
+    depth = [10, 20, 30, 100]
+
+    evaluator = pytrec_eval.RelevanceEvaluator(qrels, {'recall'})
+    scores = evaluator.evaluate(score)
+
+    for d in depth:
+        avg_score = sum([scores[qid][f'recall_{d}'] for qid in scores.keys()])/len(scores.keys())
+        print_message(f"#> Recall@{d}: {avg_score}")
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="trec.")
+
+    # Input Arguments.
+    parser.add_argument('--qrels', dest='qrels', required=True, type=str)
+    parser.add_argument('--ranking', dest='ranking', required=False, type=str)
+    parser.add_argument('--distillation_score', dest='distillation_score', required=False, type=str)
+    parser.add_argument('--ranx_score', dest='ranx_score', required=False, type=str, default=None)
+
+    args = parser.parse_args()
+
+    main(args)

--- a/utility/evaluate/trec.py
+++ b/utility/evaluate/trec.py
@@ -1,0 +1,102 @@
+"""
+    Evaluate TREC Passages ranking.
+"""
+
+import os
+import math
+import tqdm
+import json
+import random
+import pytrec_eval
+
+from ranx import Qrels, Run, evaluate
+from argparse import ArgumentParser
+from collections import defaultdict
+from colbert.utils.utils import print_message, file_tqdm
+
+def main(args):
+    print_message(f"Stating evaluation for {args.distillation_score}..")
+    # Load qrels which is a json file
+    qrels = json.load(open(args.qrels, 'r'))
+    print_message("Loaded qrels ..")
+
+    score = {}
+    if args.distillation_score is not None:
+        # Load the file line-by-line and attempt to parse each line as a JSON object
+        data_list = []
+        with open(args.distillation_score, "r") as f:
+            for line in f:
+                data_list.append(json.loads(line))
+
+        # Process the loaded data to the desired format
+        for item in data_list:
+            qid = str(item[0])
+            scores = item[1]
+            pid_score_dict = {str(score[1]): score[0] for score in scores}
+            if qid in qrels.keys():
+                score[qid] = pid_score_dict
+
+        print_message("Loaded distillation scores ..")
+
+    elif args.ranking:
+        with open(args.ranking, "r") as f:
+            for line in f:
+                qid, pid, _, points = line.strip().split("\t")
+
+                qid = str(qid)
+                pid = str(pid)
+                points = float(points)
+
+                if qid in qrels.keys():
+                    if qid not in score.keys():
+                        score[qid] = {}
+
+                    score[qid][str(pid)] = points
+    
+    elif args.ranx_score is not None:
+        # No need to load the file line-by-line and directly parse it as a JSON object
+        score = json.load(open(args.ranx_score, 'r'))
+
+        print_message("Loaded ranx scores ..")
+    
+    else:
+        raise ValueError("No score file provided. Make sure to provide either distillation score or ranx score in json format.")
+
+    # assert that the qrels keys is a subset of distillation scores keys
+    qrels_keys = set(qrels.keys())
+    score_keys = set(score.keys())
+
+    assert qrels_keys.issubset(score_keys), "qrels keys is not a subset of distillation scores keys"
+
+    print_message("#> Evaluating NDGC ..")
+    depth = [5, 10, 20, 30, 100, 200]
+
+    evaluator = pytrec_eval.RelevanceEvaluator(qrels, {'ndcg_cut'})
+    scores = evaluator.evaluate(score)
+
+    for d in depth:
+        avg_score = sum([scores[qid][f'ndcg_cut_{d}'] for qid in scores.keys()])/len(scores.keys())
+        print_message(f"#> NDGC@{d}: {avg_score}")
+    
+    print_message("#> Evaluating Recall ..")
+    depth = [20, 30, 100]
+
+    evaluator = pytrec_eval.RelevanceEvaluator(qrels, {'recall'})
+    scores = evaluator.evaluate(score)
+
+    for d in depth:
+        avg_score = sum([scores[qid][f'recall_{d}'] for qid in scores.keys()])/len(scores.keys())
+        print_message(f"#> Recall@{d}: {avg_score}")
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="trec.")
+
+    # Input Arguments.
+    parser.add_argument('--qrels', dest='qrels', required=True, type=str)
+    parser.add_argument('--ranking', dest='ranking', required=False, type=str)
+    parser.add_argument('--distillation_score', dest='distillation_score', required=False, type=str)
+    parser.add_argument('--ranx_score', dest='ranx_score', required=False, type=str, default=None)
+
+    args = parser.parse_args()
+
+    main(args)


### PR DESCRIPTION
In this PR, I'm adding support for reranker and other additional utilities, more precisely:-

* Adding support for reranker class
* Bug fix that made all the workers get the same triples
* Adding evaluation scripts for trec and stack_overflow
* Adding support to load jsonl files in query and collection
* Adding support to combine description/body with query to process SO, reddit etc. like queries
* Add triple shuffling in the code itself
* Adding BGE biencoder/reranker scorer support
* Adding base support for HF interface