### PR TITLE
Fix INDEX_ROOT is not used correctly in server.py

### DIFF
--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -20,13 +20,14 @@ TextQueries = Union[str, 'list[str]', 'dict[int, str]', Queries]
 
 
 class Searcher:
-    def __init__(self, index, checkpoint=None, collection=None, config=None):
+    def __init__(self, index, checkpoint=None, collection=None, config=None, index_root=None):
         print_memory_stats()
 
         initial_config = ColBERTConfig.from_existing(config, Run().config)
 
         default_index_root = initial_config.index_root_
-        self.index = os.path.join(default_index_root, index)
+        index_root = index_root if index_root else default_index_root
+        self.index = os.path.join(index_root, index)
         self.index_config = ColBERTConfig.load_from_index(self.index)
 
         self.checkpoint = checkpoint or self.index_config.checkpoint

--- a/server.py
+++ b/server.py
@@ -13,7 +13,7 @@ INDEX_NAME = os.getenv("INDEX_NAME")
 INDEX_ROOT = os.getenv("INDEX_ROOT")
 app = Flask(__name__)
 
-searcher = Searcher(index=f"{INDEX_ROOT}/{INDEX_NAME}")
+searcher = Searcher(index=INDEX_NAME, index_root=INDEX_ROOT)
 counter = {"api" : 0}
 
 @lru_cache(maxsize=1000000)


### PR DESCRIPTION
Seems like even if we specify `INDEX_ROOT` as environment variable, it still use `default_index_root` in searcher (which I believe is `ColBERT/experiments/default/indexes`).