### PR TITLE
chore: include important files into library for pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,12 @@ setuptools.setup(
         "tqdm",
         "transformers",
         "ujson",
-        "faiss-cpu",
     ],
-    extras_require={"faiss-gpu": ["faiss-gpu>=1.7.0"], "torch": ["torch==1.13.1"]},
+    extras_require={
+        "faiss-gpu": ["faiss-gpu>=1.7.0"],
+        "faiss-cpu": ["faiss-cpu>=1.7.0"],
+        "torch": ["torch==1.13.1"],
+    },
     include_package_data=True,
     package_data=package_data,
 )

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,23 @@
 import setuptools
 
-with open('README.md', 'r') as f:
+with open("README.md", "r") as f:
     long_description = f.read()
 
+package_data = {
+    "": ["*.cpp", "*.cu"],
+}
+
 setuptools.setup(
-    name='colbert-ir',
-    version='0.2.14',
-    author='Omar Khattab',
-    author_email='okhattab@stanford.edu',
+    name="colbert-ir",
+    version="0.2.14",
+    author="Omar Khattab",
+    author_email="okhattab@stanford.edu",
     description="Efficient and Effective Passage Search via Contextualized Late Interaction over BERT",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/stanford-futuredata/ColBERT',
+    long_description_content_type="text/markdown",
+    url="https://github.com/stanford-futuredata/ColBERT",
     packages=setuptools.find_packages(),
-    python_requires='>=3.8',
+    python_requires=">=3.8",
     install_requires=[
         "bitarray",
         "datasets",
@@ -25,11 +29,10 @@ setuptools.setup(
         "spacy",
         "tqdm",
         "transformers",
-        "ujson"
-    ], 
-    extras_require={
-        'faiss-gpu': ['faiss-gpu>=1.7.0'],
-        'torch': ['torch==1.13.1']
-    },
+        "ujson",
+        "faiss-cpu",
+    ],
+    extras_require={"faiss-gpu": ["faiss-gpu>=1.7.0"], "torch": ["torch==1.13.1"]},
     include_package_data=True,
+    package_data=package_data,
 )


### PR DESCRIPTION
Fixes #268 locally and seemingly allows for an easy `pip install colbert_ir` (or at least, removes one of the issues I'm encountering).

Main changes:

- Include faiss-cpu in the list of dependencies (might require some code modifications to make sure it explicitly uses the GPU if both are present, though I think having a functional out-of-the-box implementation is worth it?)
- Include *.cu and *.cpp files, resolving the crash at indexing time experienced in #268

Minor change:
- Uniformise all quotes to double quotes (the usage of both single and double was driving `ruff` mad)