### PR TITLE
chore: Add lightweight verbose support

### DIFF
--- a/colbert/indexer.py
+++ b/colbert/indexer.py
@@ -66,7 +66,7 @@ class Indexer:
         self.index_path = self.config.index_path_
         index_does_not_exist = (not os.path.exists(self.config.index_path_))
 
-        assert (overwrite in [True, 'reuse', 'resume']) or index_does_not_exist, self.config.index_path_
+        assert (overwrite in [True, 'reuse', 'resume', "force_silent_overwrite"]) or index_does_not_exist, self.config.index_path_
         create_directory(self.config.index_path_)
 
         if overwrite == 'force_silent_overwrite':

--- a/colbert/indexer.py
+++ b/colbert/indexer.py
@@ -13,12 +13,13 @@ from colbert.indexing.collection_indexer import encode
 
 
 class Indexer:
-    def __init__(self, checkpoint, config=None):
+    def __init__(self, checkpoint, config=None, verbose: int = 3):
         """
            Use Run().context() to choose the run's configuration. They are NOT extracted from `config`.
         """
 
         self.index_path = None
+        self.verbose = verbose
         self.checkpoint = checkpoint
         self.checkpoint_config = ColBERTConfig.load_from_checkpoint(checkpoint)
 
@@ -85,4 +86,4 @@ class Indexer:
 
         # Encodes collection into index using the CollectionIndexer class
         launcher = Launcher(encode)
-        launcher.launch(self.config, collection, shared_lists, shared_queues)
+        launcher.launch(self.config, collection, shared_lists, shared_queues, self.verbose)

--- a/colbert/indexing/collection_indexer.py
+++ b/colbert/indexing/collection_indexer.py
@@ -28,8 +28,8 @@ from colbert.utils.utils import flatten, print_message
 from colbert.indexing.codecs.residual import ResidualCodec
 
 
-def encode(config, collection, shared_lists, shared_queues):
-    encoder = CollectionIndexer(config=config, collection=collection)
+def encode(config, collection, shared_lists, shared_queues, verbose: int = 3):
+    encoder = CollectionIndexer(config=config, collection=collection, verbose=verbose)
     encoder.run(shared_lists)
 
 
@@ -38,13 +38,14 @@ class CollectionIndexer():
     Given a collection and config, encode collection into index and
     stores the index on the disk in chunks.
     '''
-    def __init__(self, config: ColBERTConfig, collection):
+    def __init__(self, config: ColBERTConfig, collection, verbose=2):
+        self.verbose = verbose
         self.config = config
         self.rank, self.nranks = self.config.rank, self.config.nranks
 
         self.use_gpu = self.config.total_visible_gpus > 0
 
-        if self.config.rank == 0:
+        if self.config.rank == 0 and self.verbose > 1:
             self.config.help()
 
         self.collection = Collection.cast(collection)
@@ -85,11 +86,12 @@ class CollectionIndexer():
         '''
         if self.config.resume:
             if self._try_load_plan():
-                Run().print_main(f"#> Loaded plan from {self.plan_path}:")
-                Run().print_main(f"#> num_chunks = {self.num_chunks}")
-                Run().print_main(f"#> num_partitions = {self.num_chunks}")
-                Run().print_main(f"#> num_embeddings_est = {self.num_embeddings_est}")
-                Run().print_main(f"#> avg_doclen_est = {self.avg_doclen_est}")
+                if self.verbose > 1:
+                    Run().print_main(f"#> Loaded plan from {self.plan_path}:")
+                    Run().print_main(f"#> num_chunks = {self.num_chunks}")
+                    Run().print_main(f"#> num_partitions = {self.num_chunks}")
+                    Run().print_main(f"#> num_embeddings_est = {self.num_embeddings_est}")
+                    Run().print_main(f"#> avg_doclen_est = {self.avg_doclen_est}")
                 return
 
         self.num_chunks = int(np.ceil(len(self.collection) / self.collection.get_chunksize()))
@@ -103,8 +105,9 @@ class CollectionIndexer():
         self.num_embeddings_est = num_passages * avg_doclen_est
         self.num_partitions = int(2 ** np.floor(np.log2(16 * np.sqrt(self.num_embeddings_est))))
 
-        Run().print_main(f'Creaing {self.num_partitions:,} partitions.')
-        Run().print_main(f'*Estimated* {int(self.num_embeddings_est):,} embeddings.')
+        if self.verbose > 0:
+            Run().print_main(f'Creating {self.num_partitions:,} partitions.')
+            Run().print_main(f'*Estimated* {int(self.num_embeddings_est):,} embeddings.')
 
         self._save_plan()
 
@@ -122,7 +125,8 @@ class CollectionIndexer():
         sampled_pids = min(1 + int(sampled_pids), num_passages)
 
         sampled_pids = random.sample(range(num_passages), sampled_pids)
-        Run().print_main(f"# of sampled PIDs = {len(sampled_pids)} \t sampled_pids[:3] = {sampled_pids[:3]}")
+        if self.verbose > 1:
+            Run().print_main(f"# of sampled PIDs = {len(sampled_pids)} \t sampled_pids[:3] = {sampled_pids[:3]}")
 
         return set(sampled_pids)
 
@@ -224,7 +228,8 @@ class CollectionIndexer():
 
         bucket_cutoffs, bucket_weights, avg_residual = self._compute_avg_residual(centroids, heldout)
 
-        print_message(f'avg_residual = {avg_residual}')
+        if self.verbose > 1:
+            print_message(f'avg_residual = {avg_residual}')
 
         # Compute and save codec into avg_residual.pt, buckets.pt and centroids.pt
         codec = ResidualCodec(config=self.config, centroids=centroids, avg_residual=avg_residual,
@@ -318,9 +323,10 @@ class CollectionIndexer():
         bucket_cutoffs = heldout_avg_residual.float().quantile(bucket_cutoffs_quantiles)
         bucket_weights = heldout_avg_residual.float().quantile(bucket_weights_quantiles)
 
-        print_message(
-            f"#> Got bucket_cutoffs_quantiles = {bucket_cutoffs_quantiles} and bucket_weights_quantiles = {bucket_weights_quantiles}")
-        print_message(f"#> Got bucket_cutoffs = {bucket_cutoffs} and bucket_weights = {bucket_weights}")
+        if self.verbose > 2:
+            print_message(
+                f"#> Got bucket_cutoffs_quantiles = {bucket_cutoffs_quantiles} and bucket_weights_quantiles = {bucket_weights_quantiles}")
+            print_message(f"#> Got bucket_cutoffs = {bucket_cutoffs} and bucket_weights = {bucket_weights}")
 
         return bucket_cutoffs, bucket_weights, avg_residual.mean()
 
@@ -344,7 +350,8 @@ class CollectionIndexer():
             batches = self.collection.enumerate_batches(rank=self.rank)
             for chunk_idx, offset, passages in tqdm.tqdm(batches, disable=self.rank > 0):
                 if self.config.resume and self.saver.check_chunk_exists(chunk_idx):
-                    Run().print_main(f"#> Found chunk {chunk_idx} in the index already, skipping encoding...")
+                    if self.verbose > 2:
+                        Run().print_main(f"#> Found chunk {chunk_idx} in the index already, skipping encoding...")
                     continue
                 # Encode passages into embeddings with the checkpoint model
                 embs, doclens = self.encoder.encode_passages(passages) 
@@ -353,9 +360,9 @@ class CollectionIndexer():
                 else:
                     assert embs.dtype == torch.float32
                     embs = embs.half()
-
-                Run().print_main(f"#> Saving chunk {chunk_idx}: \t {len(passages):,} passages "
-                                 f"and {embs.size(0):,} embeddings. From #{offset:,} onward.")
+                if self.verbose > 1:
+                    Run().print_main(f"#> Saving chunk {chunk_idx}: \t {len(passages):,} passages "
+                                    f"and {embs.size(0):,} embeddings. From #{offset:,} onward.")
 
                 self.saver.save_chunk(chunk_idx, offset, embs, doclens) # offset = first passage index in chunk
                 del embs, doclens
@@ -382,7 +389,8 @@ class CollectionIndexer():
         self._update_metadata()
 
     def _check_all_files_are_saved(self):
-        Run().print_main("#> Checking all files were saved...")
+        if self.verbose > 1:
+            Run().print_main("#> Checking all files were saved...")
         success = True
         for chunk_idx in range(self.num_chunks):
             if not self.saver.check_chunk_exists(chunk_idx):
@@ -390,7 +398,8 @@ class CollectionIndexer():
                 Run().print_main(f"#> ERROR: Could not find chunk {chunk_idx}!")
                 #TODO: Fail here?
         if success:
-            Run().print_main("Found all files!")
+            if self.verbose > 1:
+                Run().print_main("Found all files!")
 
     def _collect_embedding_id_offset(self):
         passage_offset = 0
@@ -425,12 +434,15 @@ class CollectionIndexer():
         # A loop seems nice if we can find a size that's large enough for speed yet small enough to fit on GPU!
         # Then it would help nicely for batching later: 1GB.
 
-        Run().print_main("#> Building IVF...")
+        if self.verbose > 1:
+            Run().print_main("#> Building IVF...")
 
         codes = torch.zeros(self.num_embeddings,).long()
-        print_memory_stats(f'RANK:{self.rank}')
+        if self.verbose > 1:
+            print_memory_stats(f'RANK:{self.rank}')
 
-        Run().print_main("#> Loading codes...")
+        if self.verbose > 1:
+            Run().print_main("#> Loading codes...")
 
         for chunk_idx in tqdm.tqdm(range(self.num_chunks)):
             offset = self.embedding_offsets[chunk_idx]
@@ -439,22 +451,24 @@ class CollectionIndexer():
             codes[offset:offset+chunk_codes.size(0)] = chunk_codes
 
         assert offset+chunk_codes.size(0) == codes.size(0), (offset, chunk_codes.size(0), codes.size())
+        if self.verbose > 1:
+            Run().print_main(f"Sorting codes...")
 
-        Run().print_main(f"Sorting codes...")
-
-        print_memory_stats(f'RANK:{self.rank}')
+            print_memory_stats(f'RANK:{self.rank}')
 
         codes = codes.sort()
         ivf, values = codes.indices, codes.values
 
-        print_memory_stats(f'RANK:{self.rank}')
+        if self.verbose > 1:
+            print_memory_stats(f'RANK:{self.rank}')
 
-        Run().print_main(f"Getting unique codes...")
+            Run().print_main(f"Getting unique codes...")
 
         ivf_lengths = torch.bincount(values, minlength=self.num_partitions)
         assert ivf_lengths.size(0) == self.num_partitions
 
-        print_memory_stats(f'RANK:{self.rank}')
+        if self.verbose > 1:
+            print_memory_stats(f'RANK:{self.rank}')
 
         # Transforms centroid->embedding ivf to centroid->passage ivf
         _, _ = optimize_ivf(ivf, ivf_lengths, self.config.index_path_)
@@ -462,7 +476,8 @@ class CollectionIndexer():
     def _update_metadata(self):
         config = self.config
         self.metadata_path = os.path.join(config.index_path_, 'metadata.json')
-        Run().print("#> Saving the indexing metadata to", self.metadata_path, "..")
+        if self.verbose > 1:
+            Run().print("#> Saving the indexing metadata to", self.metadata_path, "..")
 
         with open(self.metadata_path, 'w') as f:
             d = {'config': config.export()}
@@ -484,6 +499,7 @@ def compute_faiss_kmeans(dim, num_partitions, kmeans_niters, shared_lists, retur
     kmeans.train(sample)
 
     centroids = torch.from_numpy(kmeans.centroids)
+
 
     print_memory_stats(f'RANK:0*')
 

--- a/colbert/indexing/utils.py
+++ b/colbert/indexing/utils.py
@@ -5,10 +5,11 @@ import tqdm
 from colbert.indexing.loaders import load_doclens
 from colbert.utils.utils import print_message, flatten
 
-def optimize_ivf(orig_ivf, orig_ivf_lengths, index_path):
-    print_message("#> Optimizing IVF to store map from centroids to list of pids..")
+def optimize_ivf(orig_ivf, orig_ivf_lengths, index_path, verbose:int=3):
+    if verbose > 1:
+        print_message("#> Optimizing IVF to store map from centroids to list of pids..")
 
-    print_message("#> Building the emb2pid mapping..")
+        print_message("#> Building the emb2pid mapping..")
     all_doclens = load_doclens(index_path, flatten=False)
 
     # assert self.num_embeddings == sum(flatten(all_doclens))
@@ -28,7 +29,8 @@ def optimize_ivf(orig_ivf, orig_ivf_lengths, index_path):
         emb2pid[offset_doclens: offset_doclens + dlength] = pid
         offset_doclens += dlength
 
-    print_message("len(emb2pid) =", len(emb2pid))
+    if verbose > 1:
+        print_message("len(emb2pid) =", len(emb2pid))
 
     ivf = emb2pid[orig_ivf]
     unique_pids_per_centroid = []
@@ -46,9 +48,10 @@ def optimize_ivf(orig_ivf, orig_ivf_lengths, index_path):
     original_ivf_path = os.path.join(index_path, 'ivf.pt')
     optimized_ivf_path = os.path.join(index_path, 'ivf.pid.pt')
     torch.save((ivf, ivf_lengths), optimized_ivf_path)
-    print_message(f"#> Saved optimized IVF to {optimized_ivf_path}")
-    if os.path.exists(original_ivf_path):
-        print_message(f"#> Original IVF at path \"{original_ivf_path}\" can now be removed")
+    if verbose > 1:
+        print_message(f"#> Saved optimized IVF to {optimized_ivf_path}")
+        if os.path.exists(original_ivf_path):
+            print_message(f"#> Original IVF at path \"{original_ivf_path}\" can now be removed")
 
     return ivf, ivf_lengths
 

--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -15,11 +15,13 @@ class Checkpoint(ColBERT):
         TODO: Add .cast() accepting [also] an object instance-of(Checkpoint) as first argument.
     """
 
-    def __init__(self, name, colbert_config=None):
+    def __init__(self, name, colbert_config=None, verbose:int=2):
         super().__init__(name, colbert_config)
         assert self.training is False
+        
+        self.verbose = verbose
 
-        self.query_tokenizer = QueryTokenizer(self.colbert_config)
+        self.query_tokenizer = QueryTokenizer(self.colbert_config, verbose=self.verbose)
         self.doc_tokenizer = DocTokenizer(self.colbert_config)
 
         self.amp_manager = MixedPrecisionManager(True)

--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -15,10 +15,10 @@ class Checkpoint(ColBERT):
         TODO: Add .cast() accepting [also] an object instance-of(Checkpoint) as first argument.
     """
 
-    def __init__(self, name, colbert_config=None, verbose:int=2):
+    def __init__(self, name, colbert_config=None, verbose:int = 3):
         super().__init__(name, colbert_config)
         assert self.training is False
-        
+
         self.verbose = verbose
 
         self.query_tokenizer = QueryTokenizer(self.colbert_config, verbose=self.verbose)

--- a/colbert/modeling/tokenization/query_tokenization.py
+++ b/colbert/modeling/tokenization/query_tokenization.py
@@ -8,9 +8,10 @@ from colbert.parameters import DEVICE
 
 
 class QueryTokenizer():
-    def __init__(self, config: ColBERTConfig):
+    def __init__(self, config: ColBERTConfig, verbose: int = 3):
         HF_ColBERT = class_factory(config.checkpoint)
         self.tok = HF_ColBERT.raw_tokenizer_from_pretrained(config.checkpoint)
+        self.verbose = verbose
 
         self.config = config
         self.query_maxlen = config.query_maxlen
@@ -102,13 +103,13 @@ class QueryTokenizer():
             self.used = True
 
             firstbg = (context is None) or context[0]
-
-            print()
-            print("#> QueryTokenizer.tensorize(batch_text[0], batch_background[0], bsize) ==")
-            print(f"#> Input: {batch_text[0]}, \t\t {firstbg}, \t\t {bsize}")
-            print(f"#> Output IDs: {ids[0].size()}, {ids[0]}")
-            print(f"#> Output Mask: {mask[0].size()}, {mask[0]}")
-            print()
+            if self.verbose > 1:
+                print()
+                print("#> QueryTokenizer.tensorize(batch_text[0], batch_background[0], bsize) ==")
+                print(f"#> Input: {batch_text[0]}, \t\t {firstbg}, \t\t {bsize}")
+                print(f"#> Output IDs: {ids[0].size()}, {ids[0]}")
+                print(f"#> Output Mask: {mask[0].size()}, {mask[0]}")
+                print()
 
         return ids, mask
 

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -20,7 +20,7 @@ TextQueries = Union[str, 'list[str]', 'dict[int, str]', Queries]
 
 
 class Searcher:
-    def __init__(self, index, checkpoint=None, collection=None, config=None, index_root=None, verbose:int=2):
+    def __init__(self, index, checkpoint=None, collection=None, config=None, index_root=None, verbose:int = 3):
         self.verbose = verbose
         if self.verbose > 1:
             print_memory_stats()

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -20,8 +20,10 @@ TextQueries = Union[str, 'list[str]', 'dict[int, str]', Queries]
 
 
 class Searcher:
-    def __init__(self, index, checkpoint=None, collection=None, config=None, index_root=None):
-        print_memory_stats()
+    def __init__(self, index, checkpoint=None, collection=None, config=None, index_root=None, verbose:int=2):
+        self.verbose = verbose
+        if self.verbose > 1:
+            print_memory_stats()
 
         initial_config = ColBERTConfig.from_existing(config, Run().config)
 
@@ -37,7 +39,7 @@ class Searcher:
         self.collection = Collection.cast(collection or self.config.collection)
         self.configure(checkpoint=self.checkpoint, collection=self.collection)
 
-        self.checkpoint = Checkpoint(self.checkpoint, colbert_config=self.config)
+        self.checkpoint = Checkpoint(self.checkpoint, colbert_config=self.config, verbose=self.verbose)
         use_gpu = self.config.total_visible_gpus > 0
         if use_gpu:
             self.checkpoint = self.checkpoint.cuda()


### PR DESCRIPTION
Adding a basic `verbose` attribute to the noisiest classes:
- `Indexer`
- `CollectionIndexer`
- `utils.optimize_ivf`
- `QueryTokenizer`
- `Searcher`
- `Checkpoint`

Implementation is fairly noncommittal (easy to modify how we handle verbosity later).

4 levels defined:
0: Print nothing except errors
1: Level 0 + Print key information
2: Level 1 + Print most logs
3: Level 2 + Print the very noisy bucket information

Implementation defaults to level 3 (no changes from current behaviour) unless explicitly passed.

---
also fixing a one-line oversight in the previous PR with commit [d693b1a](https://github.com/stanford-futuredata/ColBERT/pull/286/commits/d693b1a077e51b67cde9513729851e4be6720c80)