### PR TITLE
FIX: Catch-all for hugging face errors

### DIFF
--- a/colbert/infra/config/base_config.py
+++ b/colbert/infra/config/base_config.py
@@ -66,7 +66,7 @@ class BaseConfig(CoreConfig):
             checkpoint_path = hf_hub_download(
                 repo_id=checkpoint_path, filename="artifact.metadata"
             ).split("artifact")[0]
-        except:
+        except Exception:
             pass
         loaded_config_path = os.path.join(checkpoint_path, "artifact.metadata")
         if os.path.exists(loaded_config_path):

--- a/colbert/infra/config/base_config.py
+++ b/colbert/infra/config/base_config.py
@@ -66,7 +66,7 @@ class BaseConfig(CoreConfig):
             checkpoint_path = hf_hub_download(
                 repo_id=checkpoint_path, filename="artifact.metadata"
             ).split("artifact")[0]
-        except RepositoryNotFoundError:
+        except:
             pass
         loaded_config_path = os.path.join(checkpoint_path, "artifact.metadata")
         if os.path.exists(loaded_config_path):


### PR DESCRIPTION
@okhat Fixing an error I introduced myself in #284, where in rare cases, other hugging face errors than just the caught one can be thrown (mostly when loading from an index rather than a checkpoint). I think while it's usually bad practice, having a catch-all except: here is pretty safe!