### PR TITLE
fix: use proper config for mp

### DIFF
--- a/colbert/infra/launcher.py
+++ b/colbert/infra/launcher.py
@@ -1,10 +1,10 @@
 import os
-import time
-import torch
 import random
+import time
 
-import torch.multiprocessing as mp
 import numpy as np
+import torch
+import torch.multiprocessing as mp
 
 try:
     mp.set_start_method('spawn', force=True)
@@ -12,10 +12,8 @@ except RuntimeError:
     pass
 
 import colbert.utils.distributed as distributed
-
-from colbert.infra.run import Run
 from colbert.infra.config import BaseConfig, RunConfig, RunSettings
-
+from colbert.infra.run import Run
 from colbert.utils.utils import print_message
 
 
@@ -31,7 +29,7 @@ class Launcher:
         assert isinstance(custom_config, BaseConfig)
         assert isinstance(custom_config, RunSettings)
         
-        if self.nranks == 1 and self.run_config.avoid_fork_if_possible:
+        if self.nranks == 1 and custom_config.avoid_fork_if_possible:
             new_config = type(custom_config).from_existing(custom_config, self.run_config, RunConfig(rank=0))
             return_val = run_process_without_mp(self.callee, new_config, *args)
             return return_val

--- a/colbert/infra/launcher.py
+++ b/colbert/infra/launcher.py
@@ -29,7 +29,7 @@ class Launcher:
         assert isinstance(custom_config, BaseConfig)
         assert isinstance(custom_config, RunSettings)
         
-        if self.nranks == 1 and custom_config.avoid_fork_if_possible:
+        if self.nranks == 1 and (custom_config.avoid_fork_if_possible or self.run_config.avoid_fork_if_possible):
             new_config = type(custom_config).from_existing(custom_config, self.run_config, RunConfig(rank=0))
             return_val = run_process_without_mp(self.callee, new_config, *args)
             return return_val


### PR DESCRIPTION
@okhat @Anmol6 fixing a small issue with the way we merged the previous avoid MP PR -- forking should be avoided if either the root or the run config specifies it, not just run config (e.g. if you run it on a no-MP platform it should be set&forget)

(apologies for the import sorter running...)