### PR TITLE
Customize batch size for document encoding in ColBERT indexing

### DIFF
--- a/colbert/indexer.py
+++ b/colbert/indexer.py
@@ -61,6 +61,8 @@ class Indexer:
         assert overwrite in [True, False, 'reuse', 'resume', "force_silent_overwrite"]
 
         self.configure(collection=collection, index_name=name, resume=overwrite=='resume')
+        # Note: The bsize value set here is ignored internally. Users are encouraged
+        # to supply their own batch size for indexing by using the index_bsize parameter in the ColBERTConfig.
         self.configure(bsize=64, partitions=None)
 
         self.index_path = self.config.index_path_

--- a/colbert/indexing/collection_encoder.py
+++ b/colbert/indexing/collection_encoder.py
@@ -22,19 +22,19 @@ class CollectionEncoder():
             # Batch here to avoid OOM from storing intermediate embeddings on GPU.
             # Storing on the GPU helps with speed of masking, etc.
             # But ideally this batching happens internally inside docFromText.
-            for passages_batch in batch(passages, self.config.bsize * 50):
-                embs_, doclens_ = self.checkpoint.docFromText(passages_batch, bsize=self.config.bsize,
+            for passages_batch in batch(passages, self.config.index_bsize * 50):
+                embs_, doclens_ = self.checkpoint.docFromText(passages_batch, bsize=self.config.index_bsize,
                                                               keep_dims='flatten', showprogress=(not self.use_gpu))
                 embs.append(embs_)
                 doclens.extend(doclens_)
 
             embs = torch.cat(embs)
 
-            # embs, doclens = self.checkpoint.docFromText(passages, bsize=self.config.bsize,
+            # embs, doclens = self.checkpoint.docFromText(passages, bsize=self.config.index_bsize,
             #                                                   keep_dims='flatten', showprogress=(self.config.rank < 1))
 
         # with torch.inference_mode():
-        #     embs = self.checkpoint.docFromText(passages, bsize=self.config.bsize,
+        #     embs = self.checkpoint.docFromText(passages, bsize=self.config.index_bsize,
         #                                        keep_dims=False, showprogress=(self.config.rank < 1))
         #     assert type(embs) is list
         #     assert len(embs) == len(passages)

--- a/colbert/indexing/collection_indexer.py
+++ b/colbert/indexing/collection_indexer.py
@@ -520,9 +520,7 @@ def compute_faiss_kmeans(dim, num_partitions, kmeans_niters, shared_lists, retur
 """
 TODOs:
 
-1. Notice we're using self.config.bsize.
+1. Consider saving/using heldout_avg_residual as a vector --- that is, using 128 averages!
 
-2. Consider saving/using heldout_avg_residual as a vector --- that is, using 128 averages!
-
-3. Consider the operations with .cuda() tensors. Are all of them good for OOM?
+2. Consider the operations with .cuda() tensors. Are all of them good for OOM?
 """

--- a/colbert/infra/config/settings.py
+++ b/colbert/infra/config/settings.py
@@ -159,6 +159,8 @@ class TrainingSettings:
 class IndexingSettings:
     index_path: str = DefaultVal(None)
 
+    index_bsize: int = DefaultVal(64)
+
     nbits: int = DefaultVal(1)
 
     kmeans_niters: int = DefaultVal(4)


### PR DESCRIPTION
This pull request addresses issue #300, allowing customization of the batch size used during the encoding in the indexing process in ColBERT.

Previously, the batch size for encoding documents when indexing was fixed to 64. Now you can specify it in the ColBERTConfig like this:
`config = ColBERTConfig(
            root="/path/to/experiments",
            index_bsize=16
)`