### PR TITLE
Returning passage ID in addition to passage index

### DIFF
--- a/colbert/data/collection.py
+++ b/colbert/data/collection.py
@@ -33,7 +33,9 @@ class Collection:
         return self._load_tsv(path) if path.endswith('.tsv') else self._load_jsonl(path)
 
     def _load_tsv(self, path):
-        return load_collection(path)
+        collection, pid_list = load_collection(path)
+        self.pid_list = pid_list
+        return collection
 
     def _load_jsonl(self, path):
         raise NotImplementedError()

--- a/colbert/evaluation/loaders.py
+++ b/colbert/evaluation/loaders.py
@@ -156,6 +156,7 @@ def load_collection(collection_path):
     print_message("#> Loading collection...")
 
     collection = []
+    pid_list = []
 
     with open(collection_path) as f:
         for line_idx, line in enumerate(f):
@@ -163,6 +164,7 @@ def load_collection(collection_path):
                 print(f'{line_idx // 1000 // 1000}M', end=' ', flush=True)
 
             pid, passage, *rest = line.strip('\n\r ').split('\t')
+            pid_list.append(pid)
             assert pid == 'id' or int(pid) == line_idx, f"pid={pid}, line_idx={line_idx}"
 
             if len(rest) >= 1:
@@ -173,7 +175,7 @@ def load_collection(collection_path):
 
     print()
 
-    return collection
+    return collection, pid_list
 
 
 def load_colbert(args, do_print=True):

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -37,6 +37,7 @@ class Searcher:
         self.config = ColBERTConfig.from_existing(self.checkpoint_config, self.index_config, initial_config)
 
         self.collection = Collection.cast(collection or self.config.collection)
+        self.pid_list = self.idx2pid(self.config.collection)
         self.configure(checkpoint=self.checkpoint, collection=self.collection)
 
         self.checkpoint = Checkpoint(self.checkpoint, colbert_config=self.config, verbose=self.verbose)
@@ -49,6 +50,14 @@ class Searcher:
         self.ranker = IndexScorer(self.index, use_gpu, load_index_with_mmap)
 
         print_memory_stats()
+        
+    def idx2pid(self, collection_path):
+        pid_list = []
+        with open(collection_path) as f:
+            for line_idx, line in enumerate(f):
+                pid, passage, *rest = line.strip('\n\r ').split('\t')
+                pid_list.append(pid)
+        return pid_list
 
     def configure(self, **kw_args):
         self.config.configure(**kw_args)


### PR DESCRIPTION
In the original repo, when you run `ranking = searcher.search_all(queries, k=100)`, the output
ranking.data is a dictionary, where each item value is a list of (passage index, ranking of passage, score of passage).
Users could also be interested in getting **the passage id (pid) (e.g., '233_4') itself instead of just the passage index (e.g., 2).** 

If we save the passage-index-to-passage-id list (`pid_list`) in the `searcher.collection`, then we can use it to easily access passage_id after ranking as follows.

```
for query_id in ranking.data:
    for (passage_index, rank, score) in ranking.data[query_id]:
        passage_id = searcher.collection.pid_list[passage_index]
```