### PR TITLE
Building ivf for large datasets

### DIFF
--- a/colbert/data/collection.py
+++ b/colbert/data/collection.py
@@ -33,7 +33,9 @@ class Collection:
         return self._load_tsv(path) if path.endswith('.tsv') else self._load_jsonl(path)
 
     def _load_tsv(self, path):
-        return load_collection(path)
+        collection, pid_list = load_collection(path)
+        self.pid_list = pid_list
+        return collection
 
     def _load_jsonl(self, path):
         raise NotImplementedError()

--- a/colbert/evaluation/loaders.py
+++ b/colbert/evaluation/loaders.py
@@ -156,6 +156,7 @@ def load_collection(collection_path):
     print_message("#> Loading collection...")
 
     collection = []
+    pid_list = []
 
     with open(collection_path) as f:
         for line_idx, line in enumerate(f):
@@ -163,6 +164,7 @@ def load_collection(collection_path):
                 print(f'{line_idx // 1000 // 1000}M', end=' ', flush=True)
 
             pid, passage, *rest = line.strip('\n\r ').split('\t')
+            pid_list.append(pid)
             assert pid == 'id' or int(pid) == line_idx, f"pid={pid}, line_idx={line_idx}"
 
             if len(rest) >= 1:
@@ -173,7 +175,7 @@ def load_collection(collection_path):
 
     print()
 
-    return collection
+    return collection, pid_list
 
 
 def load_colbert(args, do_print=True):

--- a/colbert/searcher.py
+++ b/colbert/searcher.py
@@ -37,6 +37,7 @@ class Searcher:
         self.config = ColBERTConfig.from_existing(self.checkpoint_config, self.index_config, initial_config)
 
         self.collection = Collection.cast(collection or self.config.collection)
+        self.pid_list = self.idx2pid(self.config.collection)
         self.configure(checkpoint=self.checkpoint, collection=self.collection)
 
         self.checkpoint = Checkpoint(self.checkpoint, colbert_config=self.config, verbose=self.verbose)
@@ -49,6 +50,14 @@ class Searcher:
         self.ranker = IndexScorer(self.index, use_gpu, load_index_with_mmap)
 
         print_memory_stats()
+        
+    def idx2pid(self, collection_path):
+        pid_list = []
+        with open(collection_path) as f:
+            for line_idx, line in enumerate(f):
+                pid, passage, *rest = line.strip('\n\r ').split('\t')
+                pid_list.append(pid)
+        return pid_list
 
     def configure(self, **kw_args):
         self.config.configure(**kw_args)


### PR DESCRIPTION
When using function `_build_ivf(self)` for a large corpus, it often gets stuck at the `codes = codes.sort()` step. 
To avoid sorting of a massive list, we can:
1) Create an `ivf_dict` which maps from partition index to the list of embedding indices that belong to that partition.
2) Using ivf_dict, we can easily create the following **without soring**:
- a sorted list of embedding indices (`ivf`) by just concatenating the dictionary values, and
- a list of the number of embeddings belonging to each partition (`ivf_lengths`).