### PR TITLE
Support subclassing of Collection

### DIFF
--- a/colbert/data/collection.py
+++ b/colbert/data/collection.py
@@ -94,6 +94,9 @@ class Collection:
         if type(obj) is cls:
             return obj
 
+        if isinstance(obj, cls):
+            return obj
+
         assert False, f"obj has type {type(obj)} which is not compatible with cast()"
 
 


### PR DESCRIPTION
This PR adds the ability of using subclasses of class Collection. Without this change, providing a subclass to the index functionality will cause the assert to trigger