### PR TITLE
omit tqdm when pooling embeddings for a single document

### DIFF
--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -20,7 +20,8 @@ def pool_embeddings_hierarchical(
     pooled_token_lengths = []
     start_idx = 0
 
-    for token_length in tqdm(token_lengths, desc="Pooling tokens"):
+    T = token_lengths if len(token_lengths) == 1 else tqdm(token_lengths, desc="Pooling tokens")
+    for token_length in T:
         # Get the embeddings for the current passage
         passage_embeddings = p_embeddings[start_idx : start_idx + token_length]
 

--- a/colbert/modeling/checkpoint.py
+++ b/colbert/modeling/checkpoint.py
@@ -13,6 +13,7 @@ def pool_embeddings_hierarchical(
     token_lengths,
     pool_factor,
     protected_tokens: int = 0,
+    showprogress: bool = False,
 ):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     p_embeddings = p_embeddings.to(device)
@@ -20,7 +21,7 @@ def pool_embeddings_hierarchical(
     pooled_token_lengths = []
     start_idx = 0
 
-    T = token_lengths if len(token_lengths) == 1 else tqdm(token_lengths, desc="Pooling tokens")
+    T = tqdm(token_lengths, desc="Pooling tokens") if showprogress else token_lengths
     for token_length in T:
         # Get the embeddings for the current passage
         passage_embeddings = p_embeddings[start_idx : start_idx + token_length]
@@ -180,6 +181,7 @@ class Checkpoint(ColBERT):
                         doclens,
                         pool_factor=pool_factor,
                         protected_tokens=protected_tokens,
+                        showprogress=showprogress,
                     )
 
                 return (D, doclens, *returned_text)


### PR DESCRIPTION
more generally it would be nice if ColBERT used "real" logging, or had another way to globally disable output, but this is the low hanging fruit.

(use case is for processing documents interactively instead of in batches.)