### PR TITLE
Update loaders.py to use r flag for regex

### DIFF
--- a/colbert/indexing/loaders.py
+++ b/colbert/indexing/loaders.py
@@ -22,7 +22,7 @@ def load_doclens(directory, flatten=True):
     doclens_filenames = {}
 
     for filename in os.listdir(directory):
-        match = re.match("doclens.(\d+).json", filename)
+        match = re.match(r"doclens.(\d+).json", filename)
 
         if match is not None:
             doclens_filenames[int(match.group(1))] = filename


### PR DESCRIPTION
use raw regex to avoid 

```
/lib/python3.12/site-packages/colbert/indexing/loaders.py:25: SyntaxWarning: invalid escape sequence '\d'
  match = re.match("doclens.(\d+).json", filename)
```