### PR TITLE
fix(numeric type issue): :bug: making sure the division returns an int

### DIFF
--- a/colbert/index_updater.py
+++ b/colbert/index_updater.py
@@ -199,7 +199,7 @@ class IndexUpdater:
         if curr_num_chunks == 1:
             avg_chunksize = DEFAULT_CHUNKSIZE
         else:
-            avg_chunksize = last_chunk_metadata["passage_offset"] / (
+            avg_chunksize = last_chunk_metadata["passage_offset"] // (
                 curr_num_chunks - 1
             )
         print_message(f"#> Current average chunksize is: {avg_chunksize}.")


### PR DESCRIPTION
 ### Context

While working with [RAGatouille](https://github.com/AnswerDotAI/RAGatouille/tree/main) (working with colbert-ai version 0.2.19) to build and subsequently update an index, I encountered an error related to the persist_to_disk method in the IndexUpdater class. The error message was: `TypeError: slice indices must be integers or None or have an __index__ method.`

### Analysis
Upon investigation, I identified a potential issue with the calculation of `avg_chunksize`. The value was being computed as a float, which later caused an error when attempting to use it for slicing, specifically in the calculation of `pid_end`.

To resolve this, I adjusted the computation to ensure that `avg_chunksize` is an integer. However, I have some reservations about whether this change aligns with the original algorithm's intent, given that using `a // b` results in the floor of the division.

Thank you for maintaining this repository !