### PR TITLE
use correct `gitpython`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
         "bitarray",
         "datasets",
         "flask",
-        "git-python",
+        "GitPython",
         "python-dotenv",
         "ninja",
         "scipy",


### PR DESCRIPTION
Cheers! The `setup.py` seems to be referencing the wrong `git-python`.

`git-python` technically resolves to this package here: 
https://pypi.org/project/git-python/

But the colbert source code uses the python bindings to git, aka `gitpython`, which is also consistent with your `conda_env.yaml`:
https://pypi.org/project/GitPython/