### PR TITLE
fix: AdamW import error

### DIFF
--- a/colbert/training/training.py
+++ b/colbert/training/training.py
@@ -4,7 +4,8 @@ import random
 import torch.nn as nn
 import numpy as np
 
-from transformers import AdamW, get_linear_schedule_with_warmup
+from torch.optim import AdamW
+from transformers import get_linear_schedule_with_warmup
 from colbert.infra import ColBERTConfig
 from colbert.training.rerank_batcher import RerankBatcher
 


### PR DESCRIPTION
AdamW is removed from the [latest release](https://github.com/huggingface/transformers/releases/tag/v4.50.0) of the transformers library ([PR](https://github.com/huggingface/transformers/pull/36177)) and suggested to use from `torch` 