### PR TITLE
Import AdamW from torch.optim

### DIFF
--- a/colbert/training/training.py
+++ b/colbert/training/training.py
@@ -4,7 +4,8 @@ import random
 import torch.nn as nn
 import numpy as np
 
-from transformers import AdamW, get_linear_schedule_with_warmup
+from torch.optim import AdamW
+from transformers import get_linear_schedule_with_warmup
 from colbert.infra import ColBERTConfig
 from colbert.training.rerank_batcher import RerankBatcher
 


### PR DESCRIPTION
AdamW has been deprecated and now removed in transformers (from version 2.50). Import AdamW from torch.optim instead which is suggested here:

https://github.com/huggingface/transformers/issues/36954