### PR TITLE
bugfix : Incorrect sample division for "Single-Node, Multi-GPU" ddp training

### DIFF
--- a/colbert/data/examples.py
+++ b/colbert/data/examples.py
@@ -41,7 +41,7 @@ class Examples:
 
         if rank or nranks:
             assert rank in range(nranks), (rank, nranks)
-            return [self.data[idx] for idx in range(0, len(self.data), nranks)]  # if line_idx % nranks == rank
+            return [self.data[idx + rank] for idx in range(0, len(self.data), nranks) if idx + rank < len(self.data)] # if line_idx % nranks == rank
 
         return list(self.data)
 


### PR DESCRIPTION
## Issue
https://github.com/stanford-futuredata/ColBERT/issues/403

## Main Fix 
Training Samples i.e `<query, positive_doc, negative_doc>` triples, is not correctly divided during "single-node, multi-gpu" training.

## What I checked to verify correctness

The [colbert v2 training snippet](https://github.com/stanford-futuredata/ColBERT?tab=readme-ov-file#advanced-training-colbertv2-style) from readme was used. With batch-size of 32, I ran a few iterations of training in a `single-node, two-gpu` setup. 

I added breakpoint at line 104 of `colbert/training/training.py`, and checked the scores for the first batch in two different training runs, setting `nranks` at 1 and 2. 

```
colbert.eval() ## In train mode, Dropout layers will effect output 
scores = colbert(*encoding)
```

## Training Script 
```
from colbert.infra import Run, RunConfig, ColBERTConfig
from colbert import Trainer

if __name__=='__main__':
    with Run().context(RunConfig(nranks=1, experiment="msmarco1gpu")):

        config = ColBERTConfig(
            bsize=32,
            root="/home/usd.local/robin.ranabhat/retriever/ColBERT/experiments/",
        )
        trainer = Trainer(
            triples="colbertv2.0_msmarco_64way/examples.json", # 28G, downloaded from huggingface
            # https://microsoft.github.io/msmarco/Datasets#passage-ranking-dataset
            queries="queries.train.tsv", # queries.tar.gz
            collection="collection.tsv", # collection.tar.gz
            config=config,
        )

        checkpoint_path = trainer.train()

        print(f"Saved checkpoint to {checkpoint_path}...")
```

Scores were nearly similar as expected. Minor differences should be due to default `config.amp=True`. 


## GPU Details
```
(colbert) [robin.ranabhat@usd.local@gpu001 ColBERT]$ nvidia-smi
Wed Sep 10 22:40:44 2025
+---------------------------------------------------------------------------------------+                                           
| NVIDIA-SMI 545.23.08              Driver Version: 545.23.08    CUDA Version: 12.3     |                                           
|-----------------------------------------+----------------------+----------------------+                                           
| GPU  Name                 Persistence-M | Bus-Id        Disp.A | Volatile Uncorr. ECC |                                           
| Fan  Temp   Perf          Pwr:Usage/Cap |         Memory-Usage | GPU-Util  Compute M. |                                           
|                                         |                      |               MIG M. |                                           
|=========================================+======================+======================|                                           
|   0  Tesla P100-PCIE-16GB           Off | 00000000:18:00.0 Off |                    0 |                                           
| N/A   37C    P0              32W / 250W |      0MiB / 16384MiB |      0%      Default |                                           
|                                         |                      |                  N/A |                                           
+-----------------------------------------+----------------------+----------------------+                                           
|   1  Tesla P100-PCIE-16GB           Off | 00000000:AF:00.0 Off |                    0 |                                           
| N/A   36C    P0              29W / 250W |      0MiB / 16384MiB |      1%      Default |                                           
|                                         |                      |                  N/A |                                           
+-----------------------------------------+----------------------+----------------------+                                           
                                                                                                                                    
+---------------------------------------------------------------------------------------+                                           
| Processes:                                                                            |                                           
|  GPU   GI   CI        PID   Type   Process name                            GPU Memory |                                           
|        ID   ID                                                             Usage      |                                           
|=======================================================================================|                                           
|  No running processes found                                                           |                                           
+---------------------------------------------------------------------------------------+    
```                                       
